### PR TITLE
Pass URI to server create as -f argument

### DIFF
--- a/lib/bbcloud/commands/servers-create.rb
+++ b/lib/bbcloud/commands/servers-create.rb
@@ -61,8 +61,13 @@ command [:create] do |c|
 
     if user_data_file
       raise "Cannot specify user data on command line and in file at same time" if user_data
-      File.open(user_data_file, "r") do |f|
-        raise "User data file too big (>16k)" if f.stat.size > 16 * 1024
+      require "open-uri"
+      open(user_data_file, "r") do |f|
+        file_size = case f
+        when File then f.stat.size
+        when StringIO then f.size
+        end
+        raise "User data file too big (>16k)" if file_size > 16 * 1024
         user_data = f.read
       end
     end


### PR DESCRIPTION
I have a user data script that I use to add an additional user to a server, give it passwordless sudo access and lock ssh down to only allow that user via publickey authentication. The user data script is also used by one other person to create servers in the same way. Currently we have to store and sync the script between our machines in some fashion (git repo and/or dropbox) to make sure we both have the latest version of said script before creating a server using the cli tool.

This patch allows `brightbox-servers create -f` to accept a URI as well as local filepath, so that we can just store the script at a known URL as a plaintext file and call `brightbox-servers create -f http://example.com/add-admin-user.sh img-abcde` to make sure we're always using the latest version of the script.

This patch doesn't break existing behaviour, passing a relative (or absolute) filepath still works.
