### PR TITLE
Adding ipv6_hostname field to server show output

### DIFF
--- a/lib/brightbox-cli/detailed_server.rb
+++ b/lib/brightbox-cli/detailed_server.rb
@@ -35,7 +35,7 @@ module Brightbox
       [:id, :status, :name, :created_at, :deleted_at,
         :zone, :type, :type_name, :type_handle, :ram, :cores,
         :disk, :image, :image_name, :private_ips, :cloud_ips, :ipv6_address,
-        :cloud_ip_ids, :hostname, :public_hostname, :snapshots,
+        :cloud_ip_ids, :hostname, :public_hostname, :ipv6_hostname, :snapshots,
         :server_groups
       ]
     end

--- a/lib/brightbox-cli/servers.rb
+++ b/lib/brightbox-cli/servers.rb
@@ -45,6 +45,7 @@ module Brightbox
       a[:zone] = zone && zone['handle']
       a[:hostname] = hostname
       a[:public_hostname] = public_hostname unless cloud_ips.empty?
+      a[:ipv6_hostname] = ipv6_hostname if interfaces.any? {|i| i['ipv6_address'] }
       a
     end
 
@@ -66,7 +67,10 @@ module Brightbox
     def public_hostname
       "public.#{hostname}"
     end
-  end
 
+    def ipv6_hostname
+      "ipv6.#{hostname}"
+    end
+  end
 
 end


### PR DESCRIPTION
Only outputs the hostname if there's an ipv6 address on any of the interfaces attached to that server.
