### PR TITLE
Activate console easily

### DIFF
--- a/lib/brightbox-cli/commands/servers-activate-console.rb
+++ b/lib/brightbox-cli/commands/servers-activate-console.rb
@@ -16,7 +16,8 @@ module Brightbox
       servers.each do |s|
         info "Activating console for server #{s}"
         r = s.activate_console
-        consoles << { :url => r["console_url"], :token => r["console_token"], :expires => r["console_token_expires"] }
+        url = "#{r["console_url"]}/?password=#{r["console_token"]}"
+        consoles << { :url => url, :token => r["console_token"], :expires => r["console_token_expires"] }
       end
 
       render_table(consoles, global_options.merge(:fields => [:url, :token, :expires]))


### PR DESCRIPTION
I got fed up with copying the token in and pasting it into the console form. If you pass it as ?password= in the query params it's auto-submitted and just works. This patch just changes the output of the command to append the token to the end of the URL, whilst still outputtting it in it's own field for anyone that's scripted the existing output.

eg:

```

pico:brightbox-cli(master*) caius$ be ./bin/brightbox-servers -c ea activate_console srv-2qkij
INFO: client_id: ea ()
Activating console for server srv-qqkij

 url                                                             token     expires             
------------------------------------------------------------------------------------------------
 https://srv-2qkij.console.gb1.brightbox.com/?password=zx8iiaqv  zx8iiaqv  2012-01-17T15:33:15Z
------------------------------------------------------------------------------------------------
```
