### PR TITLE
Ensure that servers are listed in a group following fog update.

### DIFF
--- a/lib/brightbox-cli/server_groups.rb
+++ b/lib/brightbox-cli/server_groups.rb
@@ -53,9 +53,7 @@ module Brightbox
     end
 
     def server_ids
-      if attributes["servers"]
-        @server_ids ||= attributes["servers"].collect { |s| s["id"] }
-      end
+      servers.map(&:id)
     end
 
   end


### PR DESCRIPTION
This replaces the server id's command with one that makes use of the fog model and pulls them from the list of servers.
