### PR TITLE
Stop ServerGroup #server_ids from calling #servers.

### DIFF
--- a/lib/brightbox-cli/server_groups.rb
+++ b/lib/brightbox-cli/server_groups.rb
@@ -52,9 +52,5 @@ module Brightbox
       server_ids.respond_to?(:join) ? server_ids.join(" ") : ""
     end
 
-    # def server_ids
-    #   servers.map(&:id)
-    # end
-
   end
 end


### PR DESCRIPTION
Servers is an expensive call. It makes a new call to get the details of every server.
