### PR TITLE
Fixes option parsing in legacy commands

### DIFF
--- a/bin/brightbox-accounts
+++ b/bin/brightbox-accounts
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("accounts")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("accounts")

--- a/bin/brightbox-cloudips
+++ b/bin/brightbox-cloudips
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("cloudips")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("cloudips")

--- a/bin/brightbox-config
+++ b/bin/brightbox-config
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("config")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("config")

--- a/bin/brightbox-firewall-policies
+++ b/bin/brightbox-firewall-policies
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("firewall-policies")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("firewall-policies")

--- a/bin/brightbox-firewall-rules
+++ b/bin/brightbox-firewall-rules
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("firewall-rules")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("firewall-rules")

--- a/bin/brightbox-groups
+++ b/bin/brightbox-groups
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("groups")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("groups")

--- a/bin/brightbox-images
+++ b/bin/brightbox-images
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("images")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("images")

--- a/bin/brightbox-lbs
+++ b/bin/brightbox-lbs
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("lbs")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("lbs")

--- a/bin/brightbox-servers
+++ b/bin/brightbox-servers
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("servers")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("servers")

--- a/bin/brightbox-types
+++ b/bin/brightbox-types
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("types")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("types")

--- a/bin/brightbox-users
+++ b/bin/brightbox-users
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("users")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("users")

--- a/bin/brightbox-zones
+++ b/bin/brightbox-zones
@@ -2,10 +2,12 @@
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("zones")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("zones")

--- a/lib/brightbox-cli/command_generator.rb
+++ b/lib/brightbox-cli/command_generator.rb
@@ -32,13 +32,15 @@ module Brightbox
 
 begin
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 rescue LoadError
   brightbox_cli_path = File.expand_path('../../lib', __FILE__)
   $:.unshift(brightbox_cli_path)
   require "brightbox_cli"
+  require "brightbox-cli/legacy/args_adjuster"
 end
 
-Brightbox::run ARGV.unshift("#{cmd_name}")
+Brightbox::run Brightbox::Legacy::ArgsAdjuster.new(ARGV).for_command("#{cmd_name}")
       EOF
       brightbox_command
     end

--- a/lib/brightbox-cli/legacy/args_adjuster.rb
+++ b/lib/brightbox-cli/legacy/args_adjuster.rb
@@ -1,0 +1,33 @@
+require "optparse"
+
+module Brightbox
+  module Legacy
+
+    # This is a simple class to take the ARGV array and inject a command in the
+    # correct position (after global options but before anything else)
+    #
+    class ArgsAdjuster
+      def initialize(args)
+        @args = args
+      end
+
+      # @param [String] command The command is insert
+      # @return [Array<String>]
+      def for_command(command)
+        @globals = []
+
+        parser = OptionParser.new do |opts|
+          opts.on("-v", "--version") {|op| @globals << "-v" }
+          opts.on("-s", "--simple") {|op| @globals << "-s" }
+          opts.on("-k", "--insecure") {|op| @globals << "-k" }
+          opts.on("-c", "--client CLIENT") {|op| @globals << "-c" << op }
+          opts.on("--account ACCOUNT") {|op| @globals << "--account" << op }
+        end
+
+        remaining = parser.parse(@args)
+
+        [] + @globals + [command] + remaining
+      end
+    end
+  end
+end

--- a/spec/unit/brightbox/legacy/args_adjuster_spec.rb
+++ b/spec/unit/brightbox/legacy/args_adjuster_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+require "brightbox-cli/legacy/args_adjuster"
+
+describe Brightbox::Legacy::ArgsAdjuster do
+
+  describe "#for_command" do
+    let(:adjuster) { Brightbox::Legacy::ArgsAdjuster.new(args) }
+
+    context "when account global switch is used" do
+      let(:args) { ["--account", "acc-12345", "show", "srv-12345"] }
+
+      it "inserts after global args" do
+        expected = ["--account", "acc-12345", "command", "show", "srv-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+
+    context "when client global switch is used" do
+      let(:args) { ["-c", "staging", "show", "srv-12345"] }
+
+      it "inserts after global args" do
+        expected = ["-c", "staging", "command", "show", "srv-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+
+    context "when simple global flag is used" do
+      let(:args) { ["--simple", "show", "srv-12345"] }
+
+      it "inserts after global args" do
+        expected = ["-s", "command", "show", "srv-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+
+    context "when insecure global switch is used" do
+      let(:args) { ["-k", "show", "srv-12345"] }
+
+      it "inserts after global args" do
+        expected = ["-k", "command", "show", "srv-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+
+    context "when many args are passed" do
+      let(:args) { ["-k", "--simple", "-c", "prod", "subcommand", "srv-12345"] }
+
+      it "inserts after global args" do
+        expected = ["-k", "-s", "-c", "prod", "command", "subcommand", "srv-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+
+    context "when no global args are used" do
+      let(:args) { ["show", "srv-12345"] }
+
+      it "inserts at the front" do
+        expected = ["command", "show", "srv-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+
+    context "when no args are used" do
+      let(:args) { [] }
+
+      it "inserts at the front" do
+        expected = ["command"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Global options must be at the start of the arguments before the command
but we simply prepended the command to the start of the args.

This actually does a first pass at parsing out the options and injects
the command between the globals and the remaining args.
