### PR TITLE
Fixes #32 - legacy command option parsing

### DIFF
--- a/lib/brightbox-cli/legacy/args_adjuster.rb
+++ b/lib/brightbox-cli/legacy/args_adjuster.rb
@@ -24,7 +24,7 @@ module Brightbox
           opts.on("--account ACCOUNT") {|op| @globals << "--account" << op }
         end
 
-        remaining = parser.parse(@args)
+        remaining = parser.order(@args)
 
         [] + @globals + [command] + remaining
       end

--- a/spec/unit/brightbox/legacy/args_adjuster_spec.rb
+++ b/spec/unit/brightbox/legacy/args_adjuster_spec.rb
@@ -68,5 +68,14 @@ describe Brightbox::Legacy::ArgsAdjuster do
         expect(adjuster.for_command "command").to eql(expected)
       end
     end
+
+    context "when subcommands have their own options" do
+      let(:args) { ["-k", "create", "-n", "Disk test", "img-12345"] }
+
+      it "doesn't raise an error" do
+        expected = ["-k", "command", "create", "-n", "Disk test", "img-12345"]
+        expect(adjuster.for_command "command").to eql(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
Flags from subcommands were not recognised by the global option parser
causing commands to be fail.

This corrects parsing to stop (without error) when non-options appear
leaving the subcommands available for GLI to process.
