### PR TITLE
[#54780074] use require instead of autoload for highline

### DIFF
--- a/lib/brightbox-cli/commands/config-user-add.rb
+++ b/lib/brightbox-cli/commands/config-user-add.rb
@@ -12,6 +12,9 @@ module Brightbox
       c.flag [:p, "password"]
 
       c.action do |global_options, options, args|
+
+        require 'highline'
+
         info "Using config file #{$config.config_filename}"
 
         email = args.shift

--- a/lib/brightbox-cli/config/cache.rb
+++ b/lib/brightbox-cli/config/cache.rb
@@ -37,6 +37,7 @@ module Brightbox
 
       def update_refresh_token
         return false unless using_application?
+        require 'highline'
         highline = HighLine.new()
         highline.say("Your API credentials have expired, enter your password to update them.")
         password = highline.ask("Enter your password : ") { |q| q.echo = false }

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -41,7 +41,6 @@ module Brightbox
   autoload :FirewallPolicy, File.expand_path("../brightbox-cli/firewall_policy", __FILE__)
   autoload :FirewallRule, File.expand_path("../brightbox-cli/firewall_rule", __FILE__)
   autoload :FirewallRules, File.expand_path("../brightbox-cli/firewall_rules", __FILE__)
-  autoload :HighLine, "highline"
 end
 
 require_relative "brightbox-cli/connection_manager"


### PR DESCRIPTION
autload works for highlinewith bundler, but not with standard rubygems
for some reason.
