### PR TITLE
Guard against invalid $cache global

### DIFF
--- a/lib/brightbox-cli/api.rb
+++ b/lib/brightbox-cli/api.rb
@@ -52,7 +52,7 @@ module Brightbox
       else
         raise InvalidArguments, "Can't initialize #{self.class} with #{m.inspect}"
       end
-      $config.cache_id @id
+      $config.cache_id(@id) if $config.respond_to?(:cache_id)
     end
 
     def fog_model


### PR DESCRIPTION
Using some of the models out of sequence fails due to bad encapsulation
and use of the $config global to cache.

```
bundle exec rspec spec/unit/brightbox/*_spec.rb
```

would fail 78 times unless specs ran after the $config was setup and
leaked from another spec.

Now we only try to cache an identifier (adds a file for autocomplete to
find) if it exists.

The caching should really be split out anyway.
