### PR TITLE
Extract #find_all_or_warn pattern into method

### DIFF
--- a/lib/brightbox-cli/api.rb
+++ b/lib/brightbox-cli/api.rb
@@ -69,6 +69,20 @@ module Brightbox
       @id
     end
 
+    # Will return everything unless a subset has been passed in
+    #
+    # @param [Array<String>] identifiers series of values to call to call
+    #
+    def self.find_all_or_warn(identifiers)
+      if identifiers.empty?
+        find(:all)
+      else
+        find_or_call(identifiers) do |identifier|
+          warn "Could not find anything with ID #{identifier}"
+        end
+      end
+    end
+
     # General finder to return instances based on identifiers or all.
     #
     # @param args    [Array<Object>, Object] Search settings. Passing +:all+

--- a/lib/brightbox-cli/commands/cloudips/list.rb
+++ b/lib/brightbox-cli/commands/cloudips/list.rb
@@ -8,15 +8,7 @@ module Brightbox
     cmd.command [:list] do |c|
 
       c.action do |global_options, options, args|
-
-        if args.empty?
-          ips = CloudIP.find(:all)
-        else
-          ips = CloudIP.find_or_call(args) do |id|
-            warn "Couldn't find Cloud IP #{id}"
-          end
-        end
-
+        ips = CloudIP.find_all_or_warn(args)
         render_table(ips.sort, global_options)
       end
     end

--- a/lib/brightbox-cli/commands/collaborations.rb
+++ b/lib/brightbox-cli/commands/collaborations.rb
@@ -8,13 +8,7 @@ module Brightbox
     cmd.arg_name "[collaboration-id...]"
     cmd.command [:list] do |c|
       c.action do |global_options, options, args|
-        if args.empty?
-          collaborations = Collaboration.find(:all)
-        else
-          collaborations = Collaboration.find_or_call(args) do |id|
-            warn "Couldn't find collaboration #{id}"
-          end
-        end
+        collaborations = Collaboration.find_all_or_warn(args)
         render_table(collaborations, global_options)
       end
     end

--- a/lib/brightbox-cli/commands/firewall/policies-list.rb
+++ b/lib/brightbox-cli/commands/firewall/policies-list.rb
@@ -8,14 +8,7 @@ module Brightbox
     cmd.command [:list] do |c|
 
       c.action do |global_options, options, args|
-
-        if args.empty?
-          firewall_policies = FirewallPolicy.find(:all)
-        else
-          firewall_policies = FirewallPolicy.find_or_call(args) do |id|
-            warn "Couldn't find firewall policy #{id}"
-          end
-        end
+        firewall_policies = FirewallPolicy.find_all_or_warn(args)
         render_table(firewall_policies, global_options)
       end
     end

--- a/lib/brightbox-cli/commands/firewall/rules-list.rb
+++ b/lib/brightbox-cli/commands/firewall/rules-list.rb
@@ -15,7 +15,7 @@ module Brightbox
         firewall_policy_id = args.shift
         raise "Invalid firewall policy id" unless firewall_policy_id =~ /^fwp-/
 
-          firewall_policy = FirewallPolicy.find_or_call([firewall_policy_id]) do |id|
+        firewall_policy = FirewallPolicy.find_or_call([firewall_policy_id]) do |id|
           raise "Couldn't find firewall policy #{id}"
         end
         render_table(FirewallRules.from_policy(firewall_policy.first), global_options)

--- a/lib/brightbox-cli/commands/groups/list.rb
+++ b/lib/brightbox-cli/commands/groups/list.rb
@@ -6,14 +6,7 @@ module Brightbox
     cmd.desc "List server groups"
     cmd.command [:list] do |c|
       c.action do |global_options, options, args|
-
-        if args.empty?
-          server_groups = ServerGroup.find(:all)
-        else
-          server_groups = ServerGroup.find_or_call(args) do |id|
-            warn "Couldn't find server group #{id}"
-          end
-        end
+        server_groups = ServerGroup.find_all_or_warn(args)
         render_table(server_groups, global_options)
       end
     end

--- a/lib/brightbox-cli/commands/images/list.rb
+++ b/lib/brightbox-cli/commands/images/list.rb
@@ -20,15 +20,7 @@ module Brightbox
       c.flag [:l, :account]
 
       c.action do |global_options, options, args|
-
-        if args.empty?
-          images = Image.find(:all)
-        else
-          images = Image.find_or_call(args) do |id|
-            warn "Couldn't find image #{id}"
-          end
-        end
-
+        images = Image.find_all_or_warn(args)
         images = Image.filter_images(images, options)
         render_table(images, global_options)
       end

--- a/lib/brightbox-cli/commands/lbs/list.rb
+++ b/lib/brightbox-cli/commands/lbs/list.rb
@@ -7,15 +7,7 @@ module Brightbox
     cmd.arg_name "[lb-id...]"
     cmd.command [:list] do |c|
       c.action do |global_options, options, args|
-
-        if args.empty?
-          lbs = LoadBalancer.find(:all)
-        else
-          lbs = LoadBalancer.find_or_call(args) do |id|
-            warn "Couldn't find load balancer #{id}"
-          end
-        end
-
+        lbs = LoadBalancer.find_all_or_warn(args)
         render_table(lbs, global_options)
       end
     end

--- a/lib/brightbox-cli/commands/servers/list.rb
+++ b/lib/brightbox-cli/commands/servers/list.rb
@@ -13,14 +13,7 @@ module Brightbox
       c.action do |global_options, options, args|
         # Check this here before we make any network connections
         raise "A valid server group identifier is required for the group argument" unless options[:g].nil? || options[:g] =~ /^grp-.{5}$/
-
-          if args.empty?
-            servers = Server.find(:all)
-        else
-          servers = Server.find_or_call(args) do |id|
-            warn "Couldn't find server #{id}"
-          end
-        end
+        servers = Server.find_all_or_warn(args)
 
         # Scope by group if a group identifier is specified
         servers = servers.select {|server| server.server_groups.any? {|grp| grp["id"] == options[:g] } } if options[:g]

--- a/lib/brightbox-cli/commands/users/list.rb
+++ b/lib/brightbox-cli/commands/users/list.rb
@@ -9,15 +9,7 @@ module Brightbox
     cmd.command [:list] do |c|
 
       c.action do |global_options, options, args|
-
-        if args.empty?
-          users = User.find(:all)
-        else
-          users = User.find_or_call(args) do |id|
-            warn "Couldn't find user #{id}"
-          end
-        end
-
+        users = User.find_all_or_warn(args)
         render_table(users, global_options)
       end
     end


### PR DESCRIPTION
Every list command followed the same pattern of showing everything if no
args are passed or filtering if some were whilst warning if the ID can't
be found.

Apart from the warning becoming generic this behaves as before whilst
simplifying things.
