### PR TITLE
Remove hard dependency on JSON gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       hirb (~> 0.6)
       i18n
       mime-types (~> 1.25)
+      multi_json
       nokogiri (~> 1.5.0)
 
 GEM
@@ -41,7 +42,7 @@ GEM
     multi_json (1.8.4)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
-    net-ssh (2.7.0)
+    net-ssh (2.8.0)
     nokogiri (1.5.11)
     pry (0.9.12.2)
       coderay (~> 1.0.5)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "gli", "~> 2.9"
   s.add_dependency "fog", "~> 1.19.0"
+  s.add_dependency "multi_json"
   s.add_dependency "nokogiri", "~> 1.5.0" # 1.5.x last versions with 1.8.7 support
   s.add_dependency "mime-types", "~> 1.25"
   s.add_dependency "excon"

--- a/lib/brightbox-cli/error_parser.rb
+++ b/lib/brightbox-cli/error_parser.rb
@@ -1,5 +1,3 @@
-require "multi_json"
-
 module Brightbox
   class ErrorParser
     include Brightbox::Logging

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -20,6 +20,7 @@ Dir.glob(vendor_dir + '/*').each do |f|
   $:.unshift File.join(f, 'lib')
 end
 
+require "multi_json"
 require 'date'
 require 'gli'
 require "i18n"


### PR DESCRIPTION
fog uses MultiJson so should be running the fastest available JSON
parser in the environment.

By isolating our one use of JSON we lose the need for the hard
dependency.

Unless you are using Bundler to isolate a command all we have done is
added a native dependency to installing the gem.
