### PR TITLE
[GH-57] Fix require to work on Ruby 1.8.7

### DIFF
--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -24,7 +24,7 @@ require "multi_json"
 require 'date'
 require 'gli'
 require "i18n"
-require "fog/brightbox/compute"
+require "fog/brightbox"
 
 # I18n stuff to clean up scattered text everywhere
 I18n.enforce_available_locales = false


### PR DESCRIPTION
Intended to narrow the scope of what is required this appears to have
silently broken the gem on Ruby 1.8.7 for no benefit.
