### PR TITLE
Replace Fog version constant

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (1.4.1)
       fog-brightbox (~> 0.7, >= 0.7.1)
-      fog-core (= 1.23)
+      fog-core (~> 1.25)
       gli (~> 2.9)
       highline (~> 1.6)
       hirb (~> 0.6)
@@ -22,7 +22,7 @@ GEM
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.23.0)
+    fog-core (1.25.0)
       builder
       excon (~> 0.38)
       formatador (~> 0.2)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "fog-brightbox", "~> 0.7", ">= 0.7.1"
-  # fog-core is broken since 1.24+ - awaiting fix to loosen dependency
-  s.add_dependency "fog-core", "= 1.23"
+  s.add_dependency "fog-core", "~> 1.25"
   s.add_dependency "gli", "~> 2.9"
   s.add_dependency "i18n"
   s.add_dependency "mime-types", "~> 1.25"

--- a/lib/brightbox-cli/gli_global_hooks.rb
+++ b/lib/brightbox-cli/gli_global_hooks.rb
@@ -50,7 +50,7 @@ module Brightbox
     # Outputs a snapshot of the tokens known by the client
     $config.debug_tokens
 
-    Excon.defaults[:headers]['User-Agent'] = "brightbox-cli/#{Brightbox::VERSION} Fog/#{Fog::VERSION}"
+    Excon.defaults[:headers]['User-Agent'] = "brightbox-cli/#{Brightbox::VERSION} Fog/#{Fog::Core::VERSION}"
 
     Excon.defaults[:headers]['User-Agent'] ||= "brightbox-cli/#{Brightbox::VERSION}"
 


### PR DESCRIPTION
A mistake in `fog-core` removed `Fog::VERSION` in a minor update which
meant the HTTP headers broke.

This uses the replacement `Fog::Core::VERSION` for the moment.

There was an issue with that originally which was why the original was
left in place but hopefully this update will be the end of the matter.
