### PR TITLE
Report non-auth exceptions during auth in DEBUG mode

### DIFF
--- a/lib/brightbox-cli/gli_global_hooks.rb
+++ b/lib/brightbox-cli/gli_global_hooks.rb
@@ -102,7 +102,12 @@ module Brightbox
       rescue Brightbox::Api::ApiError
         error "Unable to authenticate with supplied details"
         false
-      rescue
+      rescue Exception => e
+        if ENV["DEBUG"]
+          debug e
+          debug e.class.to_s
+          debug e.backtrace.join("\n")
+        end
         false
       ensure
         $config.debug_tokens


### PR DESCRIPTION
I was having a problem developing a new authentication feature but
getting no useful error messages. I discovered we've got a blanket
silent rescue in the auth handling code. I've changed it so that if
DEBUG mode is enabled, the exception is printed out.