### PR TITLE
Support encrypted stored passwords

### DIFF
--- a/README
+++ b/README
@@ -51,6 +51,50 @@ To browse available resources use the resource name as the command:
 
 Command structure may be subject to change.
 
+=== Using GPG to secure passwords
+
+If you use an OAuth application to access your accounts
+(https://www.brightbox.com/docs/guides/manager/oauth-applications/) then you
+frequently need to renter your password.
+
+From v1.5.0 you can store your password locally encrypted by GPG (https://www.gnupg.org/)
+which will decrypt the password when needed. This will prompt for your GPG key
+if not available to the GPG agent using your OS's configured pinentry program.
+
+You need to have setup GPG with your own keys and have configured the pinentry
+to prompt you when the key is locked.
+
+The password file is named after your configuration's alias:
+
+    $ brightbox config
+     alias                 client_id  secret           api_url                         auth_url
+    ------------------------------------------------------------------------------------------------------------------
+     *main                 app-12345  xxxxxxxxxxxxxxx  https://api.gb1.brightbox.com   https://api.gb1.brightbox.com
+    ------------------------------------------------------------------------------------------------------------------
+
+The alias here is `main`. To prepare the password run this command:
+
+    $ gpg --encrypt --recipient gpg@example.com > ~/.brightbox/main.password.gpg
+    (type your password)<RETURN>
+    <CTRL+D>
+    # Test it with...
+    $ gpg --decrypt ~/.brightbox/main.password.gpg
+    password!2015
+    $ brightbox accounts
+    INFO: client_id: app-12345 (main)
+    INFO: Decrypting /home/user/.brightbox/main.password.gpg to obtain password
+    gpg: encrypted with 2048-bit RSA key, ID ABCDE890, created 2015-01-01
+          "Jason Null <gpg@example.com>"
+    Your API credentials have been updated, please re-run your command.
+
+Now when making commands you should only have to unlock your keyring to avoid
+typing your password.
+
+If you are prompted to enter your password still then the file may be named
+incorrectly or there may be an issue with your GPG configuration.
+
+To remove the password delete the `~/.brightbox/main.password.gpg` file.
+
 == Usage guides
 
 * http://docs.brightbox.com/reference/cli

--- a/lib/brightbox-cli/config.rb
+++ b/lib/brightbox-cli/config.rb
@@ -12,6 +12,7 @@ module Brightbox
     require 'ini'
     include Brightbox::Logging
     include Brightbox::Config::Cache
+    include Brightbox::Config::GpgEncryptedPasswords
     include Brightbox::Config::AuthenticationTokens
     include Brightbox::Config::Accounts
     include Brightbox::Config::Clients

--- a/lib/brightbox-cli/config/authentication_tokens.rb
+++ b/lib/brightbox-cli/config/authentication_tokens.rb
@@ -189,6 +189,7 @@ module Brightbox
       def update_tokens_with_user_credentials(password = nil)
         user_application = Brightbox::Config::UserApplication.new(selected_config, client_name)
 
+        password = gpg_password unless password
         password = prompt_for_password unless password
 
         # FIXME: options are required to work

--- a/lib/brightbox-cli/config/gpg_encrypted_passwords.rb
+++ b/lib/brightbox-cli/config/gpg_encrypted_passwords.rb
@@ -1,0 +1,39 @@
+module Brightbox
+  module Config
+    module GpgEncryptedPasswords
+      attr_accessor :gpg_password
+
+      def gpg_encrypted_password_filename
+        file_name = "#{client_name}.password.gpg"
+        @gpg_encrypted_password_filename ||= File.join(config_directory, file_name)
+      end
+
+      # Return the password from gpg if it's possible
+      def gpg_password
+        if defined?(@gpg_password) && !@gpg_password.nil?
+          return @gpg_password
+        end
+        if File.exist?(gpg_encrypted_password_filename)
+          @gpg_password = gpg_decrypt_password
+        else
+          @gpg_password = nil
+        end
+      end
+
+      private
+
+      # Use gpg to decrypt the password
+      def gpg_decrypt_password
+        info "INFO: Decrypting #{gpg_encrypted_password_filename} to obtain password"
+        begin
+          IO::popen(["gpg", "--decrypt", gpg_encrypted_password_filename], "r") do |io|
+            io.read.chomp
+          end
+        rescue Errno::ENOENT
+          nil
+        end
+      end
+
+    end
+  end
+end

--- a/lib/brightbox-cli/version.rb
+++ b/lib/brightbox-cli/version.rb
@@ -1,3 +1,3 @@
 module Brightbox
-  VERSION = "1.4.2" unless defined?(Brightbox::VERSION)
+  VERSION = "1.5.0" unless defined?(Brightbox::VERSION)
 end

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -65,6 +65,7 @@ require_relative 'brightbox-cli/tables'
 require_relative "brightbox-cli/logging"
 require_relative "brightbox-cli/api"
 require_relative "brightbox-cli/config/cache"
+require_relative "brightbox-cli/config/gpg_encrypted_passwords"
 require_relative "brightbox-cli/config/authentication_tokens"
 require_relative "brightbox-cli/config/accounts"
 require_relative "brightbox-cli/config/clients"


### PR DESCRIPTION
When a password is needed for an account, check to see if it has been
gpg-encrypted and stored in a local file first, and attempt to decrypt
it with gpg.

It looks for ~/.brightbox/john@johnleach.co.uk.password.gpg and just
executes "gpg --decrypt" on it. The idea is that you'll combine it
with a gpg key daemon, such as GNOME's seahorse.

If the gpg binary isn't in the path, decryption will not be attempted
and you'll just be prompted for your password as usual.

You can encrypt a password by running this command:

gpg --encrypt --recipient john@brightbox.co.uk > ~/.brightbox/john@johnleach.co.uk.password.gpg

and then typing your password, followed by CTRL+D

Any carriage returns in the decrypted password are ignored. You can
"forget" the password by just removing that file.