### PR TITLE
New SSD default and updated autocompletion

### DIFF
--- a/lib/brightbox-cli/commands/servers/create.rb
+++ b/lib/brightbox-cli/commands/servers/create.rb
@@ -16,7 +16,7 @@ module Brightbox
       c.flag [:z, "zone"]
 
       c.desc "Type of server to create"
-      c.default_value "nano"
+      c.default_value "1gb.ssd"
       c.flag [:t, :type]
 
       c.desc "Specify user data"

--- a/tools/bash_completion_script
+++ b/tools/bash_completion_script
@@ -45,7 +45,7 @@ _brightbox()
                 return 0
                 ;;
               -t|--type)
-                COMPREPLY=( $( compgen -W 'nano mini small medium large' -- "$cur" ) )
+                COMPREPLY=( $( compgen -W 'nano mini small medium large xl xxl nano.high-io mini.high-io small.high-io medium.high-io large.high-io xl.high-io xxl.high-io 512mb.ssd 1gb.ssd 2gb.ssd 4gb.ssd 8gb.ssd 16gb.ssd 32gb.ssd 48gb.ssd 64gb.ssd 16gb.ssd-high-io 32gb.ssd-high-io 48gb.ssd-high-io 64gb.ssd-high-io' -- "$cur" ) )
                 return 0
                 ;;
             esac


### PR DESCRIPTION
This selects the new 1GB SSD server type as the default when
no argument is provided by the client.

Also updates the autocompletion list of server handles recognised.