### PR TITLE
Update `fog-brightbox` to v0.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.1.2)
-      fog-brightbox (>= 0.8.0)
+      fog-brightbox (>= 0.9.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
@@ -16,11 +16,11 @@ GEM
     coderay (1.0.9)
     diff-lcs (1.2.5)
     excon (0.45.4)
-    fog-brightbox (0.8.0)
+    fog-brightbox (0.9.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.32.0)
+    fog-core (1.32.1)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.8.0"
+  s.add_dependency "fog-brightbox", ">= 0.9.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "multi_json", "~> 1.11.0"

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_a_collection_of_Accounts.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_a_collection_of_Accounts.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -136,7 +136,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -180,7 +180,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_resources_on_the_same_connection.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_resources_on_the_same_connection.yml
@@ -48,7 +48,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_a_collection_of_Accounts.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_a_collection_of_Accounts.yml
@@ -95,7 +95,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -139,7 +139,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_resources_on_the_same_connection.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_resources_on_the_same_connection.yml
@@ -50,7 +50,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_changes_to_the_config_file.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_changes_to_the_config_file.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_default_account.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_default_account.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_new_client_as_the_default.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_new_client_as_the_default.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_is_not_authenticated/does_not_raise_an_error.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_is_not_authenticated/does_not_raise_an_error.yml
@@ -42,7 +42,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -83,7 +83,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -163,7 +163,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -243,7 +243,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -286,7 +286,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_may_access_one_account/updates_the_setting.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_may_access_one_account/updates_the_setting.yml
@@ -42,7 +42,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -83,7 +83,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -163,7 +163,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -243,7 +243,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -286,7 +286,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_config_in_use_is_not_the_default/uses_correct_credentials.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_config_in_use_is_not_the_default/uses_correct_credentials.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_a_cached_refresh_token/caches_the_new_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_a_cached_refresh_token/caches_the_new_tokens.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"aeed54b3487019931b04010b0b39715eb4e729e8"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"aeed54b3487019931b04010b0b39715eb4e729e8"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_an_expired_refresh_token/caches_the_new_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_an_expired_refresh_token/caches_the_new_tokens.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"aeed54b3487019931b04010b0b39715eb4e729e8"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"aeed54b3487019931b04010b0b39715eb4e729e8"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -51,7 +51,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/caches_the_new_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/caches_the_new_tokens.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/prompts_user_to_retry_command.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/prompts_user_to_retry_command.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_an_API_client_with_no_tokens/caches_a_new_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_an_API_client_with_no_tokens/caches_a_new_access_token.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_CloudIP/_find_all_/when_a_Cloud_IP_exists/returns_a_suitable.yml
+++ b/spec/cassettes/Brightbox_CloudIP/_find_all_/when_a_Cloud_IP_exists/returns_a_suitable.yml
@@ -208,7 +208,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -253,7 +253,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -297,7 +297,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -341,7 +341,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -385,7 +385,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -429,7 +429,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -513,7 +513,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallPolicy/_apply_to/should_apply_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_apply_to/should_apply_firewall_policy.yml
@@ -204,7 +204,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -248,7 +248,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -292,7 +292,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -336,7 +336,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -380,7 +380,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -424,7 +424,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallPolicy/_create/should_create_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_create/should_create_firewall_policy.yml
@@ -167,7 +167,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -211,7 +211,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -255,7 +255,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -299,7 +299,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -343,7 +343,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -428,7 +428,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallPolicy/_destroy/should_destroy_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_destroy/should_destroy_firewall_policy.yml
@@ -204,7 +204,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -248,7 +248,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -292,7 +292,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -336,7 +336,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -380,7 +380,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -424,7 +424,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -509,7 +509,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallPolicy/_find_all_/when_a_policy_exists/should_list_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_find_all_/when_a_policy_exists/should_list_firewall_policy.yml
@@ -169,7 +169,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -213,7 +213,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -257,7 +257,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -301,7 +301,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -345,7 +345,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -430,7 +430,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallPolicy/_find_or_call/when_a_policy_exists/should_show_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_find_or_call/when_a_policy_exists/should_show_firewall_policy.yml
@@ -167,7 +167,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -211,7 +211,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -255,7 +255,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -299,7 +299,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -343,7 +343,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallRule/_create/when_policy_exists/creates_the_rule_successfully.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_create/when_policy_exists/creates_the_rule_successfully.yml
@@ -204,7 +204,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -248,7 +248,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -292,7 +292,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -336,7 +336,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -380,7 +380,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -424,7 +424,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallRule/_destroy/when_rule_exists/destroys_a_rule.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_destroy/when_rule_exists/destroys_a_rule.yml
@@ -167,7 +167,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -211,7 +211,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -255,7 +255,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -299,7 +299,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -343,7 +343,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallRule/_find/when_rule_exists/can_display_the_result.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_find/when_rule_exists/can_display_the_result.yml
@@ -169,7 +169,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -213,7 +213,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -257,7 +257,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -301,7 +301,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -345,7 +345,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -430,7 +430,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_FirewallRule/_from_policy/when_policy_exists_with_a_rule/lists_all_rules.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_from_policy/when_policy_exists_with_a_rule/lists_all_rules.yml
@@ -245,7 +245,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -289,7 +289,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -333,7 +333,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -377,7 +377,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -421,7 +421,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -465,7 +465,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -509,7 +509,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -594,7 +594,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_destroy/when_server_exists/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_destroy/when_server_exists/should_work.yml
@@ -129,7 +129,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -173,7 +173,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -217,7 +217,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -261,7 +261,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -346,7 +346,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_find_all_/when_a_server_exists/should_print_server_list.yml
+++ b/spec/cassettes/Brightbox_Server/_find_all_/when_a_server_exists/should_print_server_list.yml
@@ -218,7 +218,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -262,7 +262,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -306,7 +306,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -350,7 +350,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -394,7 +394,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -438,7 +438,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -523,7 +523,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_show/when_server_exists/shows_detailed_attributes_of_a_server.yml
+++ b/spec/cassettes/Brightbox_Server/_show/when_server_exists/shows_detailed_attributes_of_a_server.yml
@@ -249,7 +249,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -294,7 +294,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -338,7 +338,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -382,7 +382,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -426,7 +426,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -470,7 +470,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -514,7 +514,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -598,7 +598,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_shutdown/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_shutdown/should_work.yml
@@ -248,7 +248,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -292,7 +292,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -336,7 +336,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -380,7 +380,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -424,7 +424,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -468,7 +468,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -512,7 +512,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -597,7 +597,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_start/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_start/should_work.yml
@@ -366,7 +366,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -410,7 +410,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -454,7 +454,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -498,7 +498,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -542,7 +542,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -586,7 +586,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -630,7 +630,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -674,7 +674,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -718,7 +718,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -762,7 +762,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -847,7 +847,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_stop/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_stop/should_work.yml
@@ -288,7 +288,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -332,7 +332,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -376,7 +376,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -420,7 +420,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -464,7 +464,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -508,7 +508,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -552,7 +552,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -596,7 +596,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_update/when_passing_new_group_membership/should_update_with_group.yml
+++ b/spec/cassettes/Brightbox_Server/_update/when_passing_new_group_membership/should_update_with_group.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -367,7 +367,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -411,7 +411,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -455,7 +455,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -499,7 +499,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -543,7 +543,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -587,7 +587,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -631,7 +631,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -675,7 +675,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -759,7 +759,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_ServerGroup/_find_all_/when_a_group_exists/list_server_groups.yml
+++ b/spec/cassettes/Brightbox_ServerGroup/_find_all_/when_a_group_exists/list_server_groups.yml
@@ -173,7 +173,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -217,7 +217,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -261,7 +261,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -305,7 +305,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -349,7 +349,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -434,7 +434,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Firewall_policies/update/when_the_policy_does_not_exist/prints_error_to_STDERR.yml
+++ b/spec/cassettes/Firewall_policies/update/when_the_policy_does_not_exist/prints_error_to_STDERR.yml
@@ -53,7 +53,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: ! '{"grant_type":"none","client_id":"cli-12345"}'
+      string: ! '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_access_token_expired_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_access_token_expired_/does_not_report_invalid_token_errors.yml
@@ -45,7 +45,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -131,7 +131,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"a05c73351bbbc8d3abba9cf175733aec22a5cb71"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"a05c73351bbbc8d3abba9cf175733aec22a5cb71"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -176,7 +176,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -222,7 +222,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -266,7 +266,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -310,7 +310,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"a05c73351bbbc8d3abba9cf175733aec22a5cb71"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"a05c73351bbbc8d3abba9cf175733aec22a5cb71"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -356,7 +356,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":""}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":""}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_both_tokens_expired_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_both_tokens_expired_/does_not_report_invalid_token_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -91,7 +91,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -177,7 +177,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"b57a7c633a65614b74cc29839ccfade8e64e696d"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"b57a7c633a65614b74cc29839ccfade8e64e696d"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -223,7 +223,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -268,7 +268,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -312,7 +312,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -356,7 +356,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"b57a7c633a65614b74cc29839ccfade8e64e696d"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"b57a7c633a65614b74cc29839ccfade8e64e696d"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_invalid_tokens_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_invalid_tokens_/does_not_report_invalid_token_errors.yml
@@ -45,7 +45,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"c08bd7973ddf8493d878b22fe69c1044bbb3abb1"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"c08bd7973ddf8493d878b22fe69c1044bbb3abb1"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -130,7 +130,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"c08bd7973ddf8493d878b22fe69c1044bbb3abb1"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"c08bd7973ddf8493d878b22fe69c1044bbb3abb1"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -175,7 +175,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -220,7 +220,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -265,7 +265,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -311,7 +311,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -355,7 +355,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/does_not_report_invalid_token_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -89,7 +89,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -173,7 +173,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -218,7 +218,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -263,7 +263,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -308,7 +308,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"dcd32790159f852756dadf8bed12cc3369c7b448"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"dcd32790159f852756dadf8bed12cc3369c7b448"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/reports_they_were_updated.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/reports_they_were_updated.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -89,7 +89,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -173,7 +173,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -218,7 +218,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -263,7 +263,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/does_not_report_invalid_token_errors.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -89,7 +89,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -173,7 +173,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"wrong"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"wrong"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -218,7 +218,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -263,7 +263,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/reports_unable_to_authenticate.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/reports_unable_to_authenticate.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -89,7 +89,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -173,7 +173,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"wrong"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"wrong"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -218,7 +218,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_accounts/list/does_not_error.yml
+++ b/spec/cassettes/brightbox_accounts/list/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -95,7 +95,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"app-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_cloudips/map/when_destination_is_a_server_ID/passes_the_interface_identifier_to_the_API.yml
+++ b/spec/cassettes/brightbox_cloudips/map/when_destination_is_a_server_ID/passes_the_interface_identifier_to_the_API.yml
@@ -268,7 +268,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -314,7 +314,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -360,7 +360,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -406,7 +406,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -452,7 +452,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -498,7 +498,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0

--- a/spec/cassettes/brightbox_cloudips/map/when_destination_is_another_value/passes_the_identifier_to_the_API.yml
+++ b/spec/cassettes/brightbox_cloudips/map/when_destination_is_another_value/passes_the_identifier_to_the_API.yml
@@ -181,7 +181,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -227,7 +227,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0
@@ -273,7 +273,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.19.0

--- a/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -48,7 +48,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -202,7 +202,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -245,7 +245,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -122,7 +122,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -202,7 +202,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -245,7 +245,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_change_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_change_the_default_client.yml
@@ -5,7 +5,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -122,7 +122,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -202,7 +202,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -245,7 +245,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -122,7 +122,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -202,7 +202,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -245,7 +245,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
@@ -5,7 +5,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -122,7 +122,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -202,7 +202,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -245,7 +245,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -122,7 +122,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"grant_type\":\"none\",\"client_id\":\"cli-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -202,7 +202,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0
@@ -245,7 +245,7 @@ http_interactions:
     method: post
     uri: http://api.brightbox.dev/token
     body:
-      string: "{\"client_id\":\"cli-12345\",\"grant_type\":\"none\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_NO_config_file_on_disk/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_NO_config_file_on_disk/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -90,7 +90,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -177,7 +177,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"946c0b873298d391f53f5b7d2751e6a735f6535c"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"946c0b873298d391f53f5b7d2751e6a735f6535c"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_a_default_client_is_already_set/does_not_change_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_a_default_client_is_already_set/does_not_change_the_default_client.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/display_an_warning_about_preselected_default.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/display_an_warning_about_preselected_default.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/selects_the_active_account_for_the_default.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/selects_the_active_account_for_the_default.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/display_an_warning_about_preselected_default.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/display_an_warning_about_preselected_default.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_prompt_to_rerun_the_command.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/requests_access_tokens.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -90,7 +90,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -177,7 +177,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"refresh_token","client_id":"app-12345","refresh_token":"ce9ca2cedece63cfc8ad646b13c187a5133b2d1e"}'
+      string: '{"grant_type":"refresh_token","refresh_token":"ce9ca2cedece63cfc8ad646b13c187a5133b2d1e"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_prompt_to_rerun_the_command.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/requests_access_tokens.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0
@@ -50,7 +50,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"none","client_id":"cli-12345"}'
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/does_not_error.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/requests_access_tokens.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/sets_up_the_config.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: '{"grant_type":"password","client_id":"app-12345","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_database-servers/create/--allow-access_10_0_0_0/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_database-servers/create/--allow-access_10_0_0_0/correctly_sends_API_parameters.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/create/--allow-access_srv-12345_grp-12345/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_database-servers/create/--allow-access_srv-12345_grp-12345/correctly_sends_API_parameters.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/create/--engine_mysql/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_database-servers/create/--engine_mysql/correctly_sends_API_parameters.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/create/--engine_mysql_--engine-version_5_6/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_database-servers/create/--engine_mysql_--engine-version_5_6/correctly_sends_API_parameters.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/create/without_arguments/reports_the_new_admin_password.yml
+++ b/spec/cassettes/brightbox_database-servers/create/without_arguments/reports_the_new_admin_password.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/create/without_arguments/reports_the_new_admin_username.yml
+++ b/spec/cassettes/brightbox_database-servers/create/without_arguments/reports_the_new_admin_username.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/snapshot/when_database_server_active/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_database-servers/snapshot/when_database_server_active/correctly_sends_API_parameters.yml
@@ -91,7 +91,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0
@@ -137,7 +137,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-servers/snapshot/when_database_server_can_not_be_snapshotted/reports_an_error_to_the_user.yml
+++ b/spec/cassettes/brightbox_database-servers/snapshot/when_database_server_can_not_be_snapshotted/reports_an_error_to_the_user.yml
@@ -47,7 +47,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-snapshots/list/when_resources_are_available/does_not_output_to_stderr.yml
+++ b/spec/cassettes/brightbox_database-snapshots/list/when_resources_are_available/does_not_output_to_stderr.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-snapshots/list/when_resources_are_available/outputs_table_details_to_stdout.yml
+++ b/spec/cassettes/brightbox_database-snapshots/list/when_resources_are_available/outputs_table_details_to_stdout.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0

--- a/spec/cassettes/brightbox_database-snapshots/show/when_resource_exists/does_not_output_to_stderr.yml
+++ b/spec/cassettes/brightbox_database-snapshots/show/when_resource_exists/does_not_output_to_stderr.yml
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.dev/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"none\",\"client_id\":\"app-12345\"}"
+      string: "{\"grant_type\":\"client_credentials\"}"
     headers:
       User-Agent:
       - fog/1.20.0


### PR DESCRIPTION
This updates the API calls to request tokens to match the OAuth 2.0
final spec so updates the VCR recordings to match.