### PR TITLE
Add `login` command using a default public client

### DIFF
--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -6,6 +6,9 @@ module Brightbox
     cmd.desc "password, if not specified you will be prompted"
     cmd.flag [:p, "password"]
 
+    cmd.desc "default account"
+    cmd.flag [:a, :account]
+
     cmd.flag [:"api-url"]
     cmd.flag [:"auth-url"]
 
@@ -32,13 +35,14 @@ module Brightbox
 
       raise "You must specify your Brightbox password." if password.empty?
 
-      options = {
+      section_options = {
         :username => email,
         :password => password,
         :api_url => api_url,
         :auth_url => auth_url
       }
-      $config.add_section(email, client_id, secret, options)
+      section_options[:default_account] = options[:account] if options.key?(:account)
+      $config.add_section(email, client_id, secret, section_options)
     end
   end
 end

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -9,6 +9,9 @@ module Brightbox
     cmd.desc "default account"
     cmd.flag [:a, :account]
 
+    cmd.desc "Sets alias to refer to this configuration locally (defaults to email)"
+    cmd.flag [:alias]
+
     cmd.flag [:"application-id"]
     cmd.flag [:"application-secret"]
 
@@ -18,6 +21,8 @@ module Brightbox
     cmd.action do |_global_options, options, args|
       email = args.shift
       password = options[:p]
+
+      section_name = options[:alias] || email
 
       api_url = options[:"api-url"] || DEFAULT_API_ENDPOINT
       auth_url = options[:"auth-url"] || api_url
@@ -45,7 +50,7 @@ module Brightbox
         :auth_url => auth_url
       }
       section_options[:default_account] = options[:account] if options.key?(:account)
-      $config.add_section(email, client_id, secret, section_options)
+      $config.add_section(section_name, client_id, secret, section_options)
     end
   end
 end

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -1,0 +1,44 @@
+module Brightbox
+  command [:login] do |cmd|
+    cmd.desc I18n.t("login.desc")
+    cmd.arg_name "email"
+
+    cmd.desc "password, if not specified you will be prompted"
+    cmd.flag [:p, "password"]
+
+    cmd.flag [:"api-url"]
+    cmd.flag [:"auth-url"]
+
+    cmd.action do |_global_options, options, args|
+      email = args.shift
+      password = options[:p]
+
+      api_url = options[:"api-url"] || DEFAULT_API_ENDPOINT
+      auth_url = options[:"auth-url"] || api_url
+
+      # These are public credentials and are not used for authentication
+      # They only work with a valid username and passowrd
+      # Don't use them for anything else though they can be reset at any time.
+      client_id = "app-12345"
+      secret = "mocbuipbiaa6k6c"
+
+      raise "You must specify your user's email address" if email.nil?
+
+      if !password || password.empty?
+        require "highline"
+        highline = HighLine.new
+        password = highline.ask("Enter your password : ") { |q| q.echo = false }
+      end
+
+      raise "You must specify your Brightbox password." if password.empty?
+
+      options = {
+        :username => email,
+        :password => password,
+        :api_url => api_url,
+        :auth_url => auth_url
+      }
+      $config.add_section(email, client_id, secret, options)
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -9,6 +9,9 @@ module Brightbox
     cmd.desc "default account"
     cmd.flag [:a, :account]
 
+    cmd.flag [:"application-id"]
+    cmd.flag [:"application-secret"]
+
     cmd.flag [:"api-url"]
     cmd.flag [:"auth-url"]
 
@@ -22,8 +25,8 @@ module Brightbox
       # These are public credentials and are not used for authentication
       # They only work with a valid username and passowrd
       # Don't use them for anything else though they can be reset at any time.
-      client_id = "app-12345"
-      secret = "mocbuipbiaa6k6c"
+      client_id = options[:"application-id"] || "app-12345"
+      secret = options[:"application-secret"] || "mocbuipbiaa6k6c"
 
       raise "You must specify your user's email address" if email.nil?
 

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -30,8 +30,8 @@ module Brightbox
       # These are public credentials and are not used for authentication
       # They only work with a valid username and passowrd
       # Don't use them for anything else though they can be reset at any time.
-      client_id = options[:"application-id"] || "app-12345"
-      secret = options[:"application-secret"] || "mocbuipbiaa6k6c"
+      client_id = options[:"application-id"] || Brightbox::EMBEDDED_APP_ID
+      secret = options[:"application-secret"] || Brightbox::EMBEDDED_APP_SECRET
 
       raise "You must specify your user's email address" if email.nil?
 

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -8,6 +8,7 @@ module Brightbox
       # @param [Hash] options
       # @option options [String] :username
       # @option options [String] :password
+      # @option options [String] :default_account
       # @option options [String] :api_url
       # @option options [String] :auth_url
       #
@@ -30,6 +31,7 @@ module Brightbox
         client_config["client_id"] = client_id
         client_config["username"] = options[:username]
         client_config["secret"] = secret
+        client_config["default_account"] = options[:default_account]
         client_config["api_url"] = options[:api_url] || DEFAULT_API_ENDPOINT
         client_config["auth_url"] = options[:auth_url] || client_config["api_url"]
 

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -33,6 +33,8 @@ I18n.load_path = [File.join(File.dirname(__FILE__) + "/../locales/en.yml")]
 
 module Brightbox
   DEFAULT_API_ENDPOINT = ENV["BRIGHTBOX_API_URL"] || "https://api.gb1.brightbox.com"
+  EMBEDDED_APP_ID = "app-12345"
+  EMBEDDED_APP_SECRET = "mocbuipbiaa6k6c"
 
   autoload :Server, File.expand_path("../brightbox-cli/servers", __FILE__)
   autoload :DetailedServer, File.expand_path("../brightbox-cli/detailed_server", __FILE__)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -136,6 +136,8 @@ en:
     update:
       desc: Update a load balancer
       long_desc: All intervals and timeouts are in milliseconds
+  login:
+    desc: Sign in with email and password
   servers:
     desc: Manage an account's servers
     activate_console:

--- a/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c5a03e5ea0243bee7c1d2e6e14bb8948"'
+      X-Request-Id:
+      - fc0a4931fd1722bcd21eebf56b1f215f
+      X-Runtime:
+      - '0.098245'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"c239c3d522ef3e049f6aac33e24b9c02783b6e65","token_type":"Bearer","refresh_token":"640df47cad06c789cb846856c2dfb081c07a6a08","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer c239c3d522ef3e049f6aac33e24b9c02783b6e65
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"68993de620fb03d78d3d43fadb7a7dab"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 48fbc9ae509c38f288787d9f6dae9ae7
+      X-Runtime:
+      - '0.116312'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T15:04:31Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T15:04:31Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"df87e820b206d511f8fb0c3882470a3b"'
+      X-Request-Id:
+      - 7e27fbb554681f2cb5bfad13c6fa90fc
+      X-Runtime:
+      - '0.089610'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9686b7eee00c8d09d05570f81e494a83914d2b89","token_type":"Bearer","refresh_token":"834389c6ca959ca1f8910bf8cf922f5721975658","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 9686b7eee00c8d09d05570f81e494a83914d2b89
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"68993de620fb03d78d3d43fadb7a7dab"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d3c5ff15d5b8bf81680e7ec59e153bb8
+      X-Runtime:
+      - '0.119940'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T15:04:31Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T15:04:31Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"58b116b0c2549e7418e7bdf2ee45beb0"'
+      X-Request-Id:
+      - a117812124d02da7b41db2dd6336432e
+      X-Runtime:
+      - '0.089312'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"638698ae810738dd0801a92ba5226095aad60177","token_type":"Bearer","refresh_token":"0909e2fca0d168dfe76862f3e2989e50b5f3e7e1","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 638698ae810738dd0801a92ba5226095aad60177
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"68993de620fb03d78d3d43fadb7a7dab"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fdd3ec4cdf5c2fa155ffc1940d588b9e
+      X-Runtime:
+      - '0.114221'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T15:04:31Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T15:04:31Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"41360ebc7482a4ea1507a680bcc1ea9b"'
+      X-Request-Id:
+      - 3fe490dfd5fba8a649f1fc9273f3b7e5
+      X-Runtime:
+      - '0.090356'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"96a6bfdc75e8de44961fb65f49e5a5bcb7b54937","token_type":"Bearer","refresh_token":"492036305402f9dbe340f3c42e78ca6954c7a927","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 96a6bfdc75e8de44961fb65f49e5a5bcb7b54937
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"68993de620fb03d78d3d43fadb7a7dab"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cdc441a9d45cd765e2d9ed5954cd398c
+      X-Runtime:
+      - '0.115900'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T15:04:31Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T15:04:31Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_alias_is_used_to_name_configuration/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"0ed730ace8958ebc95ce72f041792885"'
+      X-Request-Id:
+      - 483ac05aafc2c2a02bef5c87d5702691
+      X-Runtime:
+      - '0.089085'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"092e9fdc3b9d0fa48d2e222e84b495aacb28af43","token_type":"Bearer","refresh_token":"eef2d073068b0a860760a7ac6cbdc3c762aaebb4","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 092e9fdc3b9d0fa48d2e222e84b495aacb28af43
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"68993de620fb03d78d3d43fadb7a7dab"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c87c139f1bf52959e40f7cdd7b6f1830
+      X-Runtime:
+      - '0.046123'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:23:58 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T15:04:31Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T15:04:31Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:23:58 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLWRldmVsOmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"b8406ab5a282497286839f7f4150226c"'
+      X-Request-Id:
+      - 7cadfc39304f579a85848232d146a0d0
+      X-Runtime:
+      - '0.156167'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:39 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"ca5cfb3fca3e8c93098c39928d68c29514d1cbd1","token_type":"Bearer","refresh_token":"82d0b4c06946ed464e3af52c4706ae01f8a3ef15","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:39 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer ca5cfb3fca3e8c93098c39928d68c29514d1cbd1
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4f8bb0b5d81101e448a4ef2b53a7e039
+      X-Runtime:
+      - '0.045904'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:39 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:39 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLWRldmVsOmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"9df03782ba980fb33dc405234177d8b7"'
+      X-Request-Id:
+      - ee8377014f31261028dc4f0887710652
+      X-Runtime:
+      - '0.158143'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:40 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"c4e8d047fd49fc682e4b18bd2c23cd7c5909ff96","token_type":"Bearer","refresh_token":"b06ccd9eb3eebebff3b3a714ec8d58d8f6486fdd","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:40 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer c4e8d047fd49fc682e4b18bd2c23cd7c5909ff96
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - daf1d35287f9c42bd4d08f7f4f0d4cdb
+      X-Runtime:
+      - '0.045608'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:40 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:40 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLWRldmVsOmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"97cf7f8e9a47c3dd3e65129559285db1"'
+      X-Request-Id:
+      - d91264ebadc1fc4c71d36014fcc96186
+      X-Runtime:
+      - '0.088757'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:39 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"8628b0aaeff99ff35fad05837b39112f1ecca8e4","token_type":"Bearer","refresh_token":"e36d7c4a80d6095a39488e5415b371f66fc832bd","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:39 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 8628b0aaeff99ff35fad05837b39112f1ecca8e4
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f010dbfba08539db1b7ac63b6f1a8a6a
+      X-Runtime:
+      - '0.046475'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:39 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:39 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLWRldmVsOmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"6797809339a157f96189ef2c14904045"'
+      X-Request-Id:
+      - c43e9aba42ab37714b254a44f5b86a7b
+      X-Runtime:
+      - '0.088663'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:40 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"40f02b8defc01585e6652597e46011a5eac5f6e8","token_type":"Bearer","refresh_token":"8a276a84477ada449d252b613a19a6deb1fb9b55","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:40 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 40f02b8defc01585e6652597e46011a5eac5f6e8
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7df8eba8812573f8eb36aa77e80eb23c
+      X-Runtime:
+      - '0.051204'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:40 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:40 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLWRldmVsOmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"ff4d27f7aaddeb7c288f91a9b35cde77"'
+      X-Request-Id:
+      - 86b9909be0fc2636a76b02a3eeb19168
+      X-Runtime:
+      - '0.096571'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:39 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"23839d8ae1bbf295b86c52d77724e10713ab0285","token_type":"Bearer","refresh_token":"bcc919a486da09cd6c42269e2e92432b3a2a1a73","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:39 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 23839d8ae1bbf295b86c52d77724e10713ab0285
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 10ccc41f0071ad516e27a107b06a0881
+      X-Runtime:
+      - '0.113070'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 15:00:39 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 15:00:39 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"af651a3fb275b070561f181b32dceb6c"'
+      X-Request-Id:
+      - 04eb0f4a3650d6eb2f588352dea18882
+      X-Runtime:
+      - '0.089995'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:37 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"e91cf20268df3ae17504b5f3bc85d8a8a1a16302","token_type":"Bearer","refresh_token":"8cf1e4f91980f7a94a519a0c7f143aa90c601d0b","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:37 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer e91cf20268df3ae17504b5f3bc85d8a8a1a16302
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9f38b35bb188ef7a8f0c2adaf48fbd98
+      X-Runtime:
+      - '0.055426'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:37 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:37 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"ce3871d9c9acf861f882be4b94a89f50"'
+      X-Request-Id:
+      - 2c866bf58109ea6da28864f3d0b898da
+      X-Runtime:
+      - '0.092660'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:38 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"55175b15359dde5739d57e0996dd7d329839c0c6","token_type":"Bearer","refresh_token":"a0a9798376c23a63d65b85e3881b56bc37a4fcf0","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:38 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 55175b15359dde5739d57e0996dd7d329839c0c6
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 45cd804f91ae6e51b302124b38d72f8a
+      X-Runtime:
+      - '0.051219'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:38 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"1ce3de7b41fdedd149415feadbb6ccba"'
+      X-Request-Id:
+      - bb98eb1a97d43500386f472acf997a71
+      X-Runtime:
+      - '0.464089'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:36 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"1f1d143597eab83ec182ffbda817401eb5785e22","token_type":"Bearer","refresh_token":"9182decad4b7def408e11d9beea72cee4e733875","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:36 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 1f1d143597eab83ec182ffbda817401eb5785e22
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ab299a2d4d25bb72b45546864ec6aa1b
+      X-Runtime:
+      - '1.680120'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:37 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:37 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"97155ee10342a44523b1949c6f9d50eb"'
+      X-Request-Id:
+      - 14bd53791de2e9f5eb728fa6afa9d682
+      X-Runtime:
+      - '0.091759'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:38 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"b8871637ac7eea10ad7fb5cf5b044afc364e4ec2","token_type":"Bearer","refresh_token":"326094e74487443ca59607c4f051bc08f2700e52","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:38 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer b8871637ac7eea10ad7fb5cf5b044afc364e4ec2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9f4295fc42ed7ff550eac557d3200f8b
+      X-Runtime:
+      - '0.121247'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:38 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"be2bc31a57d2ac1bd275336001f344fa"'
+      X-Request-Id:
+      - dc011c858d20e2fb49cc9d9b79dc5f6a
+      X-Runtime:
+      - '0.169530'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:38 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9cf800ce314a07bd4fbfa3056bb3ec467f20773f","token_type":"Bearer","refresh_token":"662607d838a384b14f23116b3808890b390c130a","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:38 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 9cf800ce314a07bd4fbfa3056bb3ec467f20773f
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1721fee387b0118956468d75f9c1ef89
+      X-Runtime:
+      - '0.050421'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 13:51:38 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 13:51:38 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"4d7e08c1849459d093bedd5b0ef74826"'
+      X-Request-Id:
+      - cdac59322bf9145c4f3f30e3ace93158
+      X-Runtime:
+      - '0.088582'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"ab339d0e61050e052379148d9bdea5a72fa46cf6","token_type":"Bearer","refresh_token":"052aac75f305b789ae297414cdfcf93dbc7e13cd","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer ab339d0e61050e052379148d9bdea5a72fa46cf6
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 51f8d0ccacc6245e8ee0f8f253a2993a
+      X-Runtime:
+      - '0.112437'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"b045417145b24376c75fb8771284f845"'
+      X-Request-Id:
+      - 8243cf7fcd85842c309f0172255ef82e
+      X-Runtime:
+      - '0.089396'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"a57eb6f697cd504ec2ac12758bdb2fa6d191207b","token_type":"Bearer","refresh_token":"3df68d826c74fd4d92476ad2348a0080daf12631","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer a57eb6f697cd504ec2ac12758bdb2fa6d191207b
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - febae8abdca1de4d68686cc0364b611b
+      X-Runtime:
+      - '0.113624'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"66c8d174fd1b4a470dfe4a69839b9d80"'
+      X-Request-Id:
+      - f3faf9a195303a0c86baab5aa79b31e3
+      X-Runtime:
+      - '0.154162'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:35 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"f3cf25a8b2501346aeeabc7c774e83a29aad43d4","token_type":"Bearer","refresh_token":"883d6b70e55c167b8069070eef7066894d95e2d1","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:35 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer f3cf25a8b2501346aeeabc7c774e83a29aad43d4
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b39fe6c954c6ce4386f2141666168c71
+      X-Runtime:
+      - '0.044597'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:35 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:35 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"bacb98004eef14c90401caf0ba2a2a4c"'
+      X-Request-Id:
+      - edd54b71fb8783a7c2425435a8acb148
+      X-Runtime:
+      - '0.153869'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"0ff474b1064a9bbb0115c4342bcd6b131c4c91bd","token_type":"Bearer","refresh_token":"275edbf2d54f4f1237fad1b497cb992d44ce7044","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 0ff474b1064a9bbb0115c4342bcd6b131c4c91bd
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 7fb895453cb3eaab38120cf477351d23
+      X-Runtime:
+      - '0.045303'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d391536d73121b57c79332d7a80cdd9e"'
+      X-Request-Id:
+      - de9bba2dbe25a0302d415b28bbfe2523
+      X-Runtime:
+      - '0.096023'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"7ab11b0664ad510af15af667fd1d3a90f0ac2178","token_type":"Bearer","refresh_token":"d9b935d07ac45274a54fd02cca50e1f7003c645a","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 7ab11b0664ad510af15af667fd1d3a90f0ac2178
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"76f9f143bd342ee21f8f3b27b8e62089"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5929847bb22d11efc323305d00e9ef13
+      X-Runtime:
+      - '0.051266'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 23 Sep 2015 14:22:36 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-23T11:14:01Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-23T11:14:01Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 23 Sep 2015 14:22:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"2c83469a850ff81ce66a5ceae402b1d5"'
+      X-Request-Id:
+      - af215bc39f94c428495b9252301f16e9
+      X-Runtime:
+      - '0.092030'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:15 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"f39042c7a3603c483ce8bafe1f66bb75bfe3c716","token_type":"Bearer","refresh_token":"c38a40b31c9fdd355f8e5e35fd910d51108ba426","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:15 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer f39042c7a3603c483ce8bafe1f66bb75bfe3c716
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d24c99691de4ff46c6d722bc9b0a0ff1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 23fc438f8027e38ac97b6085dd103c1e
+      X-Runtime:
+      - '0.146350'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Content-Length:
+      - '6587'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":20480,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[{"id":"dbs-rucpa","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rucpa","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:25Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-w1t98","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w1t98","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:26Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-vdkdb","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-vdkdb","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:27Z","updated_at":"2015-08-19T15:57:30Z","deleted_at":null},{"id":"dbs-febmz","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-febmz","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:28Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-c3ux3","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-c3ux3","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:29Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-khick","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-khick","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:39Z","deleted_at":null},{"id":"dbs-8gi64","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-8gi64","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-dv9ut","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-dv9ut","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:39Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-gcb73","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-gcb73","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:40Z","updated_at":"2015-08-19T15:57:41Z","deleted_at":null},{"id":"dbs-5er54","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-5er54","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:41Z","updated_at":"2015-08-19T15:57:42Z","deleted_at":null}],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-08-19T14:40:23Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-08-19T14:40:23Z","description":"Applied
+        to the default server group."},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy_apply","created_at":"2015-08-19T15:57:10Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:15Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:19Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:29Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:47Z","description":null}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"1f1a46c8a9970eb7c910aaaaaa04f5cb"'
+      X-Request-Id:
+      - 86510fdae4048bbe46a2bd5c6789816a
+      X-Runtime:
+      - '0.173714'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:41 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"8abe48b8d53eb3e922863436f0aff87979388a37","token_type":"Bearer","refresh_token":"b47f48f5f9303fea99d5b4a3c63eed2dc99ac61d","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:41 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 8abe48b8d53eb3e922863436f0aff87979388a37
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"a4dbe6aa89146b2cea1f6c4d263a9ae9"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - c1261141bf5d25e385eb4fc4119b230a
+      X-Runtime:
+      - '0.054224'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:41 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-04T11:55:41Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-04T11:55:41Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:41 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c2ea8f24355677ca791991f826ecff4a"'
+      X-Request-Id:
+      - a67e48980ee85fdb1df749cded0e498f
+      X-Runtime:
+      - '0.873870'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:39 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"7b6992da77268aaae8bf392d8afc19e0f398c83d","token_type":"Bearer","refresh_token":"883ab9665dbf394a21581c942db51f09b22e7948","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:39 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 7b6992da77268aaae8bf392d8afc19e0f398c83d
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"a4dbe6aa89146b2cea1f6c4d263a9ae9"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 588a597fec7ac5147b9c17ce1dcccc68
+      X-Runtime:
+      - '1.314723'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:40 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-04T11:55:41Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-04T11:55:41Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:40 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"96b754dd5cda4f95acc513c22dc1d939"'
+      X-Request-Id:
+      - b6f888c4f8c5b3fe4e31ce7cd0b714e8
+      X-Runtime:
+      - '0.095169'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"a03f17f66e89b197a4b1a40b1ce9f160821b80e7","token_type":"Bearer","refresh_token":"dbdeebbc35668335c003185a80352a49209b89fc","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer a03f17f66e89b197a4b1a40b1ce9f160821b80e7
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d24c99691de4ff46c6d722bc9b0a0ff1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0352b4027a7a0937e31789422e02d175
+      X-Runtime:
+      - '0.145677'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Content-Length:
+      - '6587'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":20480,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[{"id":"dbs-rucpa","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rucpa","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:25Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-w1t98","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w1t98","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:26Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-vdkdb","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-vdkdb","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:27Z","updated_at":"2015-08-19T15:57:30Z","deleted_at":null},{"id":"dbs-febmz","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-febmz","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:28Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-c3ux3","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-c3ux3","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:29Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-khick","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-khick","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:39Z","deleted_at":null},{"id":"dbs-8gi64","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-8gi64","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-dv9ut","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-dv9ut","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:39Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-gcb73","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-gcb73","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:40Z","updated_at":"2015-08-19T15:57:41Z","deleted_at":null},{"id":"dbs-5er54","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-5er54","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:41Z","updated_at":"2015-08-19T15:57:42Z","deleted_at":null}],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-08-19T14:40:23Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-08-19T14:40:23Z","description":"Applied
+        to the default server group."},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy_apply","created_at":"2015-08-19T15:57:10Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:15Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:19Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:29Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:47Z","description":null}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"6b3305c6910899b348acd7008363182b"'
+      X-Request-Id:
+      - e49d7fa4584a252690f036b2a57d0f61
+      X-Runtime:
+      - '0.094315'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"4d66fada4b4001a738982c77b64cb59b842d819f","token_type":"Bearer","refresh_token":"5998027d6299180e0108b13a5dc7cb295f4faf49","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 4d66fada4b4001a738982c77b64cb59b842d819f
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d24c99691de4ff46c6d722bc9b0a0ff1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 15f8055cbc0204d7a34353a942325080
+      X-Runtime:
+      - '0.076197'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Content-Length:
+      - '6587'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":20480,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[{"id":"dbs-rucpa","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rucpa","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:25Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-w1t98","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w1t98","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:26Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-vdkdb","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-vdkdb","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:27Z","updated_at":"2015-08-19T15:57:30Z","deleted_at":null},{"id":"dbs-febmz","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-febmz","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:28Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-c3ux3","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-c3ux3","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:29Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-khick","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-khick","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:39Z","deleted_at":null},{"id":"dbs-8gi64","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-8gi64","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-dv9ut","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-dv9ut","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:39Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-gcb73","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-gcb73","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:40Z","updated_at":"2015-08-19T15:57:41Z","deleted_at":null},{"id":"dbs-5er54","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-5er54","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:41Z","updated_at":"2015-08-19T15:57:42Z","deleted_at":null}],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-08-19T14:40:23Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-08-19T14:40:23Z","description":"Applied
+        to the default server group."},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy_apply","created_at":"2015-08-19T15:57:10Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:15Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:19Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:29Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:47Z","description":null}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"112a1a3d435c9989e1e5281384aa0243"'
+      X-Request-Id:
+      - 1d2c2bb72d6ab168ffde6b8ffaf05c67
+      X-Runtime:
+      - '0.092256'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:41 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9c6800d98fcdcefac769b125aba0adf0b7977dcb","token_type":"Bearer","refresh_token":"a2faeb48743b2436428275d19b9276e1543e50b1","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:41 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 9c6800d98fcdcefac769b125aba0adf0b7977dcb
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"a4dbe6aa89146b2cea1f6c4d263a9ae9"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5156bdcffc03632834561354b1179d8e
+      X-Runtime:
+      - '0.121563'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:41 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-04T11:55:41Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-04T11:55:41Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:41 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"09a202b8090a76d40bfc201a76606dae"'
+      X-Request-Id:
+      - 432ae412a84fd41a51144756b147bb72
+      X-Runtime:
+      - '0.088209'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"db82ab3f954f6d8bd6280775c9a427f0c699b0f9","token_type":"Bearer","refresh_token":"bf124c9f033408f647b9d2d85ce9b02b2326fbb7","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer db82ab3f954f6d8bd6280775c9a427f0c699b0f9
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d24c99691de4ff46c6d722bc9b0a0ff1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 35c2dfe68198a330b188fccdfc452b74
+      X-Runtime:
+      - '0.083600'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:16 GMT
+      Content-Length:
+      - '6587'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":20480,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[{"id":"dbs-rucpa","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rucpa","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:25Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-w1t98","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w1t98","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:26Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-vdkdb","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-vdkdb","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:27Z","updated_at":"2015-08-19T15:57:30Z","deleted_at":null},{"id":"dbs-febmz","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-febmz","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:28Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-c3ux3","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-c3ux3","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:29Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-khick","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-khick","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:39Z","deleted_at":null},{"id":"dbs-8gi64","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-8gi64","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-dv9ut","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-dv9ut","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:39Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-gcb73","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-gcb73","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:40Z","updated_at":"2015-08-19T15:57:41Z","deleted_at":null},{"id":"dbs-5er54","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-5er54","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:41Z","updated_at":"2015-08-19T15:57:42Z","deleted_at":null}],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-08-19T14:40:23Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-08-19T14:40:23Z","description":"Applied
+        to the default server group."},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy_apply","created_at":"2015-08-19T15:57:10Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:15Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:19Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:29Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:47Z","description":null}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"3bce07dc8d4a5fa631b5716cd2e8eed4"'
+      X-Request-Id:
+      - 920e19a2a8c194a22751944b6418376b
+      X-Runtime:
+      - '0.092682'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:41 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"c51deb93e9a7239007162e41cbf4a070db41e32a","token_type":"Bearer","refresh_token":"5d0712bda24cce2973a23f812fa7835420eaad7e","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:41 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer c51deb93e9a7239007162e41cbf4a070db41e32a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"a4dbe6aa89146b2cea1f6c4d263a9ae9"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5af8e51ab9a1fe74a8f3989781676cbe
+      X-Runtime:
+      - '0.122322'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Fri, 04 Sep 2015 12:03:41 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-04T11:55:41Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-04T11:55:41Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Fri, 04 Sep 2015 12:03:41 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"34fd9a5f4ba621163e255c796197982b"'
+      X-Request-Id:
+      - 376b158c041d0db38a828c493e999c00
+      X-Runtime:
+      - '0.160218'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:17 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"e927821e5ad5d0870b22038f8bd4d48207c5ef6d","token_type":"Bearer","refresh_token":"ba8a47db5717c89f683c5081c178f1a7e50fe660","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:17 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer e927821e5ad5d0870b22038f8bd4d48207c5ef6d
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d24c99691de4ff46c6d722bc9b0a0ff1"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 99397532d43003fa01a10f95f88b7211
+      X-Runtime:
+      - '0.076358'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Thu, 20 Aug 2015 12:47:17 GMT
+      Content-Length:
+      - '6587'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":20480,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[{"id":"dbs-rucpa","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rucpa","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:25Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-w1t98","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w1t98","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:26Z","updated_at":"2015-08-19T15:57:29Z","deleted_at":null},{"id":"dbs-vdkdb","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-vdkdb","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:27Z","updated_at":"2015-08-19T15:57:30Z","deleted_at":null},{"id":"dbs-febmz","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-febmz","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:28Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-c3ux3","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-c3ux3","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:29Z","updated_at":"2015-08-19T15:57:31Z","deleted_at":null},{"id":"dbs-khick","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-khick","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:39Z","deleted_at":null},{"id":"dbs-8gi64","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-8gi64","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:38Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-dv9ut","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-dv9ut","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:39Z","updated_at":"2015-08-19T15:57:40Z","deleted_at":null},{"id":"dbs-gcb73","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-gcb73","name":"","description":"","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:40Z","updated_at":"2015-08-19T15:57:41Z","deleted_at":null},{"id":"dbs-5er54","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-5er54","name":"","description":"","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.6","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"created_at":"2015-08-19T15:57:41Z","updated_at":"2015-08-19T15:57:42Z","deleted_at":null}],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-08-19T14:40:23Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-08-19T14:40:23Z","description":"Applied
+        to the default server group."},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy_apply","created_at":"2015-08-19T15:57:10Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:15Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:19Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":null,"created_at":"2015-08-19T15:57:29Z","description":null},{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":false,"name":"rspec_firewall_policy","created_at":"2015-08-19T15:57:47Z","description":null}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Thu, 20 Aug 2015 12:47:17 GMT
+recorded_with: VCR 2.9.3

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -155,4 +155,50 @@ describe "brightbox login" do
       expect(stderr).to_not include("please re-run your command")
     end
   end
+
+  context "when default account is passed", vcr: true do
+    let(:account) { "acc-23456" }
+    let(:argv) { ["login", "--account", account, email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["auth_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["alias"]).to eql(client_alias)
+      expect(@client_section["client_id"]).to eql(client_id)
+      expect(@client_section["secret"]).to eql(secret)
+      expect(@client_section["default_account"]).to eql(account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
 end

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -201,4 +201,47 @@ describe "brightbox login" do
       expect(stderr).to_not include("please re-run your command")
     end
   end
+
+  context "when alternative client credentials are given", vcr: true do
+    let(:other_client_identifier) { "app-23456" }
+    let(:other_client_secret) { "ho04hondtzjjdf4" }
+    let(:argv) { ["login", "--application-id", other_client_identifier, "--application-secret", other_client_secret, email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["client_id"]).to eql(other_client_identifier)
+      expect(@client_section["secret"]).to eql(other_client_secret)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
 end

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+
+describe "brightbox login" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  let(:email) { "jason.null@brightbox.com" }
+  let(:password) { "N:B3e%7Cmh" }
+  let(:client_id) { "app-12345" }
+  let(:secret) { "mocbuipbiaa6k6c" }
+  let(:api_url) { "http://api.brightbox.dev" }
+
+  let(:default_account) { "acc-12345" }
+  let(:client_alias) { email }
+
+  context "when no arguments are given" do
+    let(:argv) { %w(login) }
+
+    it "errors prompting for the email address" do
+      remove_config
+      expect(stderr).to include("You must specify your user's email address")
+    end
+  end
+
+  context "when no config is present", vcr: true do
+    let(:argv) { ["login", "-p", password, email] }
+
+    before do
+      remove_config
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["alias"]).to eql(client_alias)
+      expect(@client_section["client_id"]).to eql(client_id)
+      expect(@client_section["secret"]).to eql(secret)
+      expect(@client_section["default_account"]).to eql(default_account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+
+  context "when no password is given", vcr: true do
+    let(:argv) { ["login", email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["alias"]).to eql(client_alias)
+      expect(@client_section["client_id"]).to eql(client_id)
+      expect(@client_section["secret"]).to eql(secret)
+      expect(@client_section["default_account"]).to eql(default_account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+end

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -244,4 +244,45 @@ describe "brightbox login" do
       expect(stderr).to_not include("please re-run your command")
     end
   end
+
+  context "when alias is used to name configuration", vcr: true do
+    let(:client_alias) { "production" }
+    let(:argv) { ["login", "--alias", client_alias, email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[client_alias]
+
+      expect(@client_section["alias"]).to eql(client_alias)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => client_alias
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
 end


### PR DESCRIPTION
Rather than needing to go and create a user application of their own,
this uses a public, general client for the CLI so only username/password
are required.