### PR TITLE
Limit Net::SSH dependency for Ruby 1.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ PATH
       hirb (~> 0.6)
       i18n (~> 0.6.0)
       multi_json (~> 1.11.0)
+      net-ssh (< 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -38,7 +39,7 @@ GEM
     inflecto (0.0.2)
     metaclass (0.0.1)
     method_source (0.8.1)
-    mime-types (2.6.1)
+    mime-types (2.6.2)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
@@ -73,4 +74,4 @@ DEPENDENCIES
   vcr (~> 2.5)
 
 BUNDLED WITH
-   1.10.2
+   1.10.6

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "multi_json", "~> 1.11.0"
+  s.add_dependency "net-ssh", "< 3.0"
   s.add_dependency "highline", "~> 1.6.0"
   s.add_dependency "hirb", "~> 0.6"
 


### PR DESCRIPTION
`net-ssh` 3.0 dropped 1.9.3 support. Attempting to install the CLI on
ruby 1.9.3 would fail as it pulled in the incompatible gem versions.

This limits the version (which is not directly used) to allow
installation to work.