### PR TITLE
[#105296840] Default to embedded app if not set

### DIFF
--- a/lib/brightbox-cli/commands/config/client-list.rb
+++ b/lib/brightbox-cli/commands/config/client-list.rb
@@ -21,8 +21,8 @@ module Brightbox
 
           {
             :alias => calias,
-            :client_id => c["client_id"],
-            :secret => c["secret"],
+            :client_id => c["client_id"] || Brightbox::EMBEDDED_APP_ID,
+            :secret => c["secret"] || Brightbox::EMBEDDED_APP_SECRET,
             :api_url => c["api_url"],
             :auth_url => c["auth_url"] || c["api_url"]
           }

--- a/lib/brightbox-cli/config/clients.rb
+++ b/lib/brightbox-cli/config/clients.rb
@@ -8,7 +8,11 @@ module Brightbox
 
       # Is the currently selected config using user application details?
       def using_application?
-        config_identifier_match_prefix?("app")
+        if selected_config
+          !selected_config["username"].nil?
+        else
+          raise NoSelectedClientError, NO_CLIENT_MESSAGE
+        end
       end
 
       # Does this config have multiple clients defined within?

--- a/lib/brightbox-cli/config/user_application.rb
+++ b/lib/brightbox-cli/config/user_application.rb
@@ -3,7 +3,7 @@ module Brightbox
     class UserApplication
       # FIXME: api_url should use fog's underlying default
       #
-      NON_BLANK_KEYS = %w(api_url client_id secret username)
+      NON_BLANK_KEYS = %w(api_url username)
 
       attr_accessor :selected_config, :client_name
 
@@ -19,8 +19,8 @@ module Brightbox
           :provider => 'Brightbox',
           :brightbox_api_url => selected_config['api_url'],
           :brightbox_auth_url => selected_config['auth_url'] || selected_config['api_url'],
-          :brightbox_client_id => selected_config['client_id'],
-          :brightbox_secret => selected_config['secret'],
+          :brightbox_client_id => client_id,
+          :brightbox_secret => client_secret,
           :persistent => persistent?
         }
       end
@@ -55,6 +55,14 @@ module Brightbox
 
       private
 
+      def client_id
+        selected_config["client_id"] || Brightbox::EMBEDDED_APP_ID
+      end
+
+      def client_secret
+        selected_config["secret"] || Brightbox::EMBEDDED_APP_SECRET
+      end
+
       def persistent?
         if selected_config["persistent"] == "false"
           false
@@ -68,8 +76,8 @@ module Brightbox
           :provider => 'Brightbox',
           :brightbox_api_url => selected_config['api_url'],
           :brightbox_auth_url => selected_config['auth_url'] || selected_config['api_url'],
-          :brightbox_client_id => selected_config['client_id'],
-          :brightbox_secret => selected_config['secret'],
+          :brightbox_client_id => client_id,
+          :brightbox_secret => client_secret,
           :brightbox_username => selected_config["username"],
           :persistent => persistent?
         }

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -33,6 +33,8 @@ I18n.load_path = [File.join(File.dirname(__FILE__) + "/../locales/en.yml")]
 
 module Brightbox
   DEFAULT_API_ENDPOINT = ENV["BRIGHTBOX_API_URL"] || "https://api.gb1.brightbox.com"
+  EMBEDDED_APP_ID = "app-12345"
+  EMBEDDED_APP_SECRET = "mocbuipbiaa6k6c"
 
   autoload :Server, File.expand_path("../brightbox-cli/servers", __FILE__)
   autoload :DetailedServer, File.expand_path("../brightbox-cli/detailed_server", __FILE__)

--- a/spec/configs/user_app.ini
+++ b/spec/configs/user_app.ini
@@ -3,8 +3,6 @@ default_client = testing
 
 [testing]
 alias = testing
-client_id = app-12345
-secret = mocbuipbiaa6k6c
 username = jason.null@brightbox.com
 api_url = http://api.brightbox.dev
 auth_url = http://api.brightbox.dev

--- a/spec/unit/brightbox/bb_config/using_client_spec.rb
+++ b/spec/unit/brightbox/bb_config/using_client_spec.rb
@@ -2,20 +2,20 @@ require "spec_helper"
 
 describe Brightbox::BBConfig do
   let(:api_client_id) { "cli-12345" }
-  let(:user_client_id) { "app-12345" }
-  let(:user_app_two) { "app-54321" }
+  let(:custom_app) { "app-54321" }
+  let(:username) { "jason.null@brightbox.com" }
 
   let(:contents) do
     <<-EOS
     [#{api_client_id}]
     client_id = #{api_client_id}
     secret = #{random_token}
-    [#{user_client_id}]
-    client_id = #{user_client_id}
+    [#{username}]
+    username = #{username}
+    [#{custom_app}]
+    client_id = #{custom_app}
     secret = #{random_token}
-    [#{user_app_two}]
-    client_id = #{user_app_two}
-    secret = #{random_token}
+    username = #{username}
     EOS
   end
 
@@ -36,7 +36,7 @@ describe Brightbox::BBConfig do
     end
 
     context "when selected config is for a user application" do
-      let(:client_name) { user_client_id }
+      let(:client_name) { username }
 
       it "returns true" do
         config.client_name = client_name
@@ -54,7 +54,7 @@ describe Brightbox::BBConfig do
     end
 
     context "when selected config is for a user application with generic key" do
-      let(:client_name) { user_app_two }
+      let(:client_name) { custom_app }
 
       it "returns true" do
         config.client_name = client_name
@@ -69,7 +69,7 @@ describe Brightbox::BBConfig do
         remove_config
       end
 
-      it "does not raise an error" do
+      it "raises an error" do
         expect do
           Brightbox::BBConfig.new.using_api_client?
         end.to raise_error(Brightbox::NoSelectedClientError, error_message)
@@ -77,7 +77,7 @@ describe Brightbox::BBConfig do
     end
 
     context "when selected config is for a user application" do
-      let(:client_name) { user_client_id }
+      let(:client_name) { username }
 
       it "returns false" do
         config.client_name = client_name
@@ -95,7 +95,7 @@ describe Brightbox::BBConfig do
     end
 
     context "when selected config is for a user application with generic key" do
-      let(:client_name) { user_app_two }
+      let(:client_name) { custom_app }
 
       it "returns false" do
         config.client_name = client_name

--- a/spec/unit/brightbox/config/user_application/to_fog_spec.rb
+++ b/spec/unit/brightbox/config/user_application/to_fog_spec.rb
@@ -11,7 +11,41 @@ describe Brightbox::Config::UserApplication do
   subject(:for_fog) { section.to_fog }
 
   describe "#to_fog" do
-    context "when config is valid" do
+    context "when config is using embedded client" do
+      let(:contents) do
+        <<-EOS
+        [#{client_name}]
+        api_url = http://api.brightbox.dev
+        username = user@example.com
+        EOS
+      end
+
+      it "sets provider as 'Brightbox'" do
+        expect(for_fog[:provider]).to eql("Brightbox")
+      end
+
+      it "sets API endpoint correctly" do
+        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+      end
+
+      it "copies API endpoint for auth endpoint correctly" do
+        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.dev")
+      end
+
+      it "sets client_id correctly" do
+        expect(for_fog[:brightbox_client_id]).to eql(Brightbox::EMBEDDED_APP_ID)
+      end
+
+      it "sets secret correctly" do
+        expect(for_fog[:brightbox_secret]).to eql(Brightbox::EMBEDDED_APP_SECRET)
+      end
+
+      it "sets persistent correctly" do
+        expect(for_fog[:persistent]).to be true
+      end
+    end
+
+    context "when config is using custom client" do
       let(:contents) do
         <<-EOS
         [#{client_name}]
@@ -97,36 +131,6 @@ describe Brightbox::Config::UserApplication do
 
       it "raises error" do
         expect { section.to_fog }.to raise_error(Brightbox::BBConfigError, "api_url option missing from config in section app-12345")
-      end
-    end
-
-    context "when config is missing client_id" do
-      let(:contents) do
-        <<-EOS
-        [#{client_name}]
-        api_url = http://api.brightbox.dev
-        secret = #{secret}
-        username = user@example.com
-        EOS
-      end
-
-      it "raises error" do
-        expect { section.to_fog }.to raise_error(Brightbox::BBConfigError, "client_id option missing from config in section app-12345")
-      end
-    end
-
-    context "when config is missing secret" do
-      let(:contents) do
-        <<-EOS
-        [#{client_name}]
-        api_url = http://api.brightbox.dev
-        client_id = #{client_name}
-        username = user@example.com
-        EOS
-      end
-
-      it "raises error" do
-        expect { section.to_fog }.to raise_error(Brightbox::BBConfigError, "secret option missing from config in section app-12345")
       end
     end
 

--- a/spec/unit/brightbox/config/user_application/valid_spec.rb
+++ b/spec/unit/brightbox/config/user_application/valid_spec.rb
@@ -13,8 +13,6 @@ describe Brightbox::Config::UserApplication do
         <<-EOS
         [#{client_name}]
         api_url = http://api.brightbox.dev
-        client_id = #{client_name}
-        secret = #{random_token}
         username = user@example.com
         EOS
       end
@@ -47,36 +45,6 @@ describe Brightbox::Config::UserApplication do
         [#{client_name}]
         client_id = #{client_name}
         secret = #{random_token}
-        username = user@example.com
-        EOS
-      end
-
-      it "is invalid" do
-        expect(section).to_not be_valid
-      end
-    end
-
-    context "when config is missing client_id" do
-      let(:contents) do
-        <<-EOS
-        [#{client_name}]
-        api_url = http://api.brightbox.dev
-        secret = #{random_token}
-        username = user@example.com
-        EOS
-      end
-
-      it "is invalid" do
-        expect(section).to_not be_valid
-      end
-    end
-
-    context "when config is missing secret" do
-      let(:contents) do
-        <<-EOS
-        [#{client_name}]
-        api_url = http://api.brightbox.dev
-        client_id = #{client_name}
         username = user@example.com
         EOS
       end


### PR DESCRIPTION
This adds a default user application set of credentials (which still
MUST be used with a username/password) which are used if the ID/secret
are not configured.

This will allow us to cut down the complexity of setting up new
configurations since only the email (username) and password (prompt)
will be needed.