### PR TITLE
Reduce complexity of `BBConfig#client_name`

### DIFF
--- a/lib/brightbox-cli/config/accounts.rb
+++ b/lib/brightbox-cli/config/accounts.rb
@@ -22,6 +22,11 @@ module Brightbox
         end
       end
 
+      def determine_account(preferred_account)
+        return preferred_account if preferred_account
+        return config[client_name]["default_account"] unless client_name.nil?
+      end
+
       def account
         if defined?(@account) && @account
           @account

--- a/lib/brightbox-cli/config/clients.rb
+++ b/lib/brightbox-cli/config/clients.rb
@@ -73,7 +73,7 @@ module Brightbox
 
       # Returns the actual client ID with no risk of an alias
       def client_id
-        selected_config["client_id"]
+        selected_config["client_id"] || Brightbox::EMBEDDED_APP_ID
       end
 
       # @todo Account for "core" section

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -12,8 +12,8 @@ module Brightbox
       # @option options [String] :auth_url
       #
       def add_section(client_alias, client_id, secret, options)
-        client_config = config[client_alias]
-        if client_config.empty?
+        config_section = config[client_alias]
+        if config_section.empty?
           info "Creating new client config #{client_alias}"
         else
           old_calias = client_alias
@@ -21,17 +21,17 @@ module Brightbox
           deduplicator = Brightbox::Config::SectionNameDeduplicator.new(client_alias, section_names)
           client_alias = deduplicator.next
           # Need to open the new config again
-          client_config = config[client_alias]
+          config_section = config[client_alias]
 
           info "A client config named #{old_calias} already exists using #{client_alias} instead"
         end
 
-        client_config["alias"] = client_alias
-        client_config["client_id"] = client_id
-        client_config["username"] = options[:username]
-        client_config["secret"] = secret
-        client_config["api_url"] = options[:api_url] || DEFAULT_API_ENDPOINT
-        client_config["auth_url"] = options[:auth_url] || client_config["api_url"]
+        config_section["alias"] = client_alias
+        config_section["client_id"] = client_id
+        config_section["username"] = options[:username]
+        config_section["secret"] = secret
+        config_section["api_url"] = options[:api_url] || DEFAULT_API_ENDPOINT
+        config_section["auth_url"] = options[:auth_url] || config_section["api_url"]
 
         dirty!
 

--- a/lib/brightbox-cli/gli_global_hooks.rb
+++ b/lib/brightbox-cli/gli_global_hooks.rb
@@ -41,7 +41,7 @@ module Brightbox
     Brightbox.config = BBConfig.new(config_opts)
 
     # Commands that alter the config files should not error here
-    unless [:config].include?(command.topmost_ancestor.name)
+    unless [:config, :login].include?(command.topmost_ancestor.name)
       raise AmbiguousClientError, AMBIGUOUS_CLIENT_ERROR if Brightbox.config.client_name.nil?
 
       if Brightbox.config.has_multiple_clients?

--- a/lib/brightbox-cli/gli_global_hooks.rb
+++ b/lib/brightbox-cli/gli_global_hooks.rb
@@ -33,22 +33,28 @@ module Brightbox
   switch [:k, :insecure], :negatable => false
 
   pre do |global_options, command, _options, _args|
-    if command.topmost_ancestor.name == :config
-      force_default_config = false
-    else
-      force_default_config = true
-    end
-
     # Configuration options
     config_opts = {
-      :force_default_config => force_default_config,
       :client_name => ENV["CLIENT"] || global_options[:client],
       :account => ENV["ACCOUNT"] || global_options[:account]
     }
     Brightbox.config = BBConfig.new(config_opts)
 
-    # Outputs a snapshot of the tokens known by the client
-    Brightbox.config.debug_tokens if Brightbox.config.respond_to?(:debug_tokens)
+    # Commands that alter the config files should not error here
+    unless [:config].include?(command.topmost_ancestor.name)
+      raise AmbiguousClientError, AMBIGUOUS_CLIENT_ERROR if Brightbox.config.client_name.nil?
+
+      if Brightbox.config.has_multiple_clients?
+        if Brightbox.config.client_has_alias?
+          info "INFO: client_id: #{Brightbox.config.client_name} (#{Brightbox.config.client_alias})"
+        else
+          info "INFO: client_id: #{Brightbox.config.client_name}"
+        end
+      end
+
+      # Outputs a snapshot of the tokens known by the client
+      Brightbox.config.debug_tokens if Brightbox.config.respond_to?(:debug_tokens)
+    end
 
     Excon.defaults[:headers]['User-Agent'] = "brightbox-cli/#{Brightbox::VERSION} Fog/#{Fog::Core::VERSION}"
 
@@ -63,13 +69,6 @@ module Brightbox
       Hirb::View.resize
     end
 
-    if Brightbox.config.has_multiple_clients?
-      if Brightbox.config.client_has_alias?
-        info "INFO: client_id: #{Brightbox.config.client_id} (#{Brightbox.config.client_alias})"
-      else
-        info "INFO: client_id: #{Brightbox.config.client_id}"
-      end
-    end
     true
   end
 

--- a/spec/commands/accounts/list_spec.rb
+++ b/spec/commands/accounts/list_spec.rb
@@ -60,6 +60,7 @@ describe "brightbox accounts" do
 
       before do
         config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+        #mock_password_entry(password)
 
         # Setup in the VCR recordings as the access token is expired
         cache_access_token(config, "08f204123bb2fc400521577445df9d1d212da42e")

--- a/spec/support/config_helpers.rb
+++ b/spec/support/config_helpers.rb
@@ -16,6 +16,8 @@ module ConfigHelpers
       f.write contents
     end
 
+    config = Brightbox::BBConfig.new
+
     # Subvert the global
     Brightbox.config = config
 

--- a/spec/unit/brightbox/bb_config/account_spec.rb
+++ b/spec/unit/brightbox/bb_config/account_spec.rb
@@ -35,6 +35,8 @@ describe Brightbox::BBConfig do
         @account_name = "acc-ghj32"
         @client_name = "app-b3n5b"
         contents = <<-EOS
+        [core]
+        default_client = #{@client_name}
         [#{@client_name}]
         default_account = #{@account_name}
         EOS

--- a/spec/unit/brightbox/bb_config/client_name_spec.rb
+++ b/spec/unit/brightbox/bb_config/client_name_spec.rb
@@ -56,39 +56,31 @@ describe Brightbox::BBConfig do
         [cli-12345]
         client_id = cli-12345
         EOS
-        @tmp_config = TmpConfig.new(contents)
-      end
-
-      after do
-        @tmp_config.close
+        config_from_contents(contents)
       end
 
       context "and force_default_config is on" do
         before do
           config_opts = {
-            :directory => @tmp_config.path,
             :force_default_config => true
           }
           @config = Brightbox::BBConfig.new(config_opts)
         end
 
-        it "raises an error" do
-          expect do
-            @config.client_name
-          end.to raise_error(Brightbox::BBConfigError, "You must specify a default client using brightbox config client_default")
+        it "returns nil" do
+          expect(@config.client_name).to be_nil
         end
       end
 
       context "and force_default_config is off" do
         before do
           config_opts = {
-            :directory => @tmp_config.path,
             :force_default_config => false
           }
           @config = Brightbox::BBConfig.new(config_opts)
         end
 
-        it "returns first client" do
+        it "returns nil" do
           expect(@config.client_name).to be_nil
         end
       end

--- a/spec/unit/brightbox/bb_config/config_directory_spec.rb
+++ b/spec/unit/brightbox/bb_config/config_directory_spec.rb
@@ -13,13 +13,15 @@ describe Brightbox::BBConfig do
     end
 
     context "when absolute custom location is set" do
+      let(:custom_dir) { Dir.mktmpdir("custom") }
+
       it "returns a String of the expanded directory" do
         config_options = {
-          :directory => "/etc/local/brightbox_cli"
+          :directory => custom_dir
         }
         config = Brightbox::BBConfig.new(config_options)
 
-        expect(config.config_directory).to eql("/etc/local/brightbox_cli")
+        expect(config.config_directory).to eql(custom_dir)
       end
     end
 

--- a/spec/unit/brightbox/bb_config/config_spec.rb
+++ b/spec/unit/brightbox/bb_config/config_spec.rb
@@ -10,7 +10,6 @@ describe Brightbox::BBConfig do
         Dir.mktmpdir do |tmp_dir|
           target_dir = File.join(tmp_dir, "config")
           @config = Brightbox::BBConfig.new :directory => target_dir
-          expect(@config.config_directory_exists?).to be false
           example.run
         end
       end
@@ -62,20 +61,17 @@ describe Brightbox::BBConfig do
     end
 
     context "when config file can not be parsed" do
-      around do |example|
+      it "raises an error" do
         Dir.mktmpdir do |target_dir|
           test_config_filename = File.join(target_dir, "config")
           File.open(test_config_filename, "w") do |f|
             f.puts "not:ini"
           end
 
-          @config = Brightbox::BBConfig.new :directory => target_dir
-          example.run
+          expect {
+            @config = Brightbox::BBConfig.new :directory => target_dir
+          }.to raise_error(Brightbox::BBConfigError)
         end
-      end
-
-      it "raises an error" do
-        expect { @config.config }.to raise_error(Brightbox::BBConfigError)
       end
     end
   end

--- a/spec/unit/brightbox/bb_config/default_account_spec.rb
+++ b/spec/unit/brightbox/bb_config/default_account_spec.rb
@@ -43,13 +43,17 @@ describe Brightbox::BBConfig do
     end
 
     context "when set in config" do
-      before do
-        @account_name = "acc-ghj32"
-        @client_name = "app-b3n5b"
-        contents = <<-EOS
-        [#{@client_name}]
-        default_account = #{@account_name}
+      let(:account_name) { "acc-ghj32" }
+      let(:client_name) { "app-b3n5b" }
+
+      let(:contents) do
+        <<-EOS
+        [#{client_name}]
+        default_account = #{account_name}
         EOS
+      end
+
+      before do
         @config = config_from_contents(contents)
       end
 

--- a/spec/unit/brightbox/bb_config/find_or_set_default_account_spec.rb
+++ b/spec/unit/brightbox/bb_config/find_or_set_default_account_spec.rb
@@ -61,6 +61,8 @@ describe Brightbox::BBConfig do
     context "when client may access one account", vcr: true do
       let(:contents) do
         <<-EOS
+        [core]
+        default_client = cli-12345
         [cli-12345]
         api_url = http://api.brightbox.dev
         client_id = cli-12345

--- a/spec/unit/brightbox/bb_config/renew_tokens_spec.rb
+++ b/spec/unit/brightbox/bb_config/renew_tokens_spec.rb
@@ -15,6 +15,9 @@ describe Brightbox::BBConfig do
     context "when using a user app with no tokens", vcr: true do
       before do
         contents = <<-EOS
+        [core]
+        default_client = app-12345
+
         [app-12345]
         api_url = #{api_endpoint}
         client_id = #{app_id}


### PR DESCRIPTION
The original implementation of `#client_name` and `#config` relied
on side-effects in the behaviour of the config.

Creating it was a lighter process, then referencing `#config` would
create directories, load the ini file. However it meant a number of
methods were equally complex because they had to call this
internally.

For `#selected_config` this also hit `#client_name` that performed
a few things and erred if config data was missing or ambiguous.

Trying to setup a new configuration section would then end up with
a series of problems when adding one would be impossible because
a later step referenced a full config.

The workaround used previously `force_default_config` appears to
be buggy in that it just skipped raising one error in one check but
the wrong client would be returned by `#client_name` so token exchange
would be with the wrong client.

This sets up a simpler `login` command