### PR TITLE
Add `login` command using a default public client

### DIFF
--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -7,7 +7,7 @@ module Brightbox
     cmd.flag [:p, "password"]
 
     cmd.desc "default account"
-    cmd.flag [:a, :account]
+    cmd.flag [:"default-account"]
 
     cmd.flag [:"application-id"]
     cmd.flag [:"application-secret"]
@@ -42,7 +42,7 @@ module Brightbox
         :api_url => api_url,
         :auth_url => auth_url
       }
-      section_options[:default_account] = options[:account] if options[:account]
+      section_options[:default_account] = options[:"default-account"] if options[:"default-account"]
 
       section_options[:client_id] = options[:"application-id"] if options[:"application-id"]
       section_options[:secret] = options[:"application-secret"] if options[:"application-secret"]

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -1,0 +1,53 @@
+module Brightbox
+  command [:login] do |cmd|
+    cmd.desc I18n.t("login.desc")
+    cmd.arg_name "email"
+
+    cmd.desc "password, if not specified you will be prompted"
+    cmd.flag [:p, "password"]
+
+    cmd.desc "default account"
+    cmd.flag [:a, :account]
+
+    cmd.flag [:"application-id"]
+    cmd.flag [:"application-secret"]
+
+    cmd.flag [:"api-url"]
+    cmd.flag [:"auth-url"]
+
+    cmd.action do |_global_options, options, args|
+      config_name = args.shift
+      email = config_name
+
+      raise "You must specify your email address" if email.nil?
+
+      password = options[:p]
+      password = Brightbox.config.gpg_password unless password
+
+      if !password || password.empty?
+        require "highline"
+        highline = HighLine.new
+        password = highline.ask("Enter your password : ") { |q| q.echo = false }
+      end
+      raise "You must specify your Brightbox password." if password.empty?
+
+      api_url = options[:"api-url"] || DEFAULT_API_ENDPOINT
+      auth_url = options[:"auth-url"] || api_url
+
+      section_options = {
+        :client_name => config_name,
+        :alias => config_name,
+        :username => email,
+        :password => password,
+        :api_url => api_url,
+        :auth_url => auth_url
+      }
+      section_options[:default_account] = options[:account] if options[:account]
+
+      section_options[:client_id] = options[:"application-id"] if options[:"application-id"]
+      section_options[:secret] = options[:"application-secret"] if options[:"application-secret"]
+
+      Brightbox.config.add_login(email, password, section_options)
+    end
+  end
+end

--- a/lib/brightbox-cli/config/accounts.rb
+++ b/lib/brightbox-cli/config/accounts.rb
@@ -22,6 +22,11 @@ module Brightbox
         end
       end
 
+      def determine_account(preferred_account)
+        return preferred_account if preferred_account
+        return config[client_name]["default_account"] unless client_name.nil?
+      end
+
       def account
         if defined?(@account) && @account
           @account

--- a/lib/brightbox-cli/config/authentication_tokens.rb
+++ b/lib/brightbox-cli/config/authentication_tokens.rb
@@ -4,7 +4,7 @@ module Brightbox
       attr_writer :access_token, :refresh_token
 
       def access_token_filename
-        file_name = "#{client_name}.oauth_token"
+        file_name = "#{base_token_name}.oauth_token"
         @access_token_filename ||= File.join(config_directory, file_name)
       end
 
@@ -20,7 +20,7 @@ module Brightbox
       end
 
       def refresh_token_filename
-        file_name = "#{client_name}.refresh_token"
+        file_name = "#{base_token_name}.refresh_token"
         @refresh_token_filename ||= File.join(config_directory, file_name)
       end
 
@@ -233,6 +233,13 @@ module Brightbox
 
       def cached_refresh_token
         File.open(refresh_token_filename, "r") { |fl| fl.read.chomp }
+      end
+
+      private
+
+      def base_token_name
+        return nil if client_name.nil?
+        client_name.gsub("/", "_")
       end
     end
   end

--- a/lib/brightbox-cli/config/clients.rb
+++ b/lib/brightbox-cli/config/clients.rb
@@ -73,7 +73,7 @@ module Brightbox
 
       # Returns the actual client ID with no risk of an alias
       def client_id
-        selected_config["client_id"]
+        selected_config["client_id"] || Brightbox::EMBEDDED_APP_ID
       end
 
       # @todo Account for "core" section

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -2,22 +2,21 @@ module Brightbox
   module Config
     module Sections
       #
-      # @param [String] email
+      # @param [String] config_alias The section name usually `email` but `email/suffix` allowed.
       # @param [String] password
       # @param [Hash] options
-      # @option options [String] :alias
       # @option options [String] :api_url
       # @option options [String] :auth_url
       # @option options [String] :default_account
       # @option options [String] :client_id
       # @option options [String] :secret
       #
-      def add_login(email, password, options = {})
+      def add_login(config_alias, password, options = {})
         # If a custom alias is passed, used that for the config header, otherwise use email
-        config_alias = options[:alias] || email
+        email = config_alias.split("/").first
         config_section = config[config_alias]
 
-        info "Creating new client config #{email}" if config_section.empty?
+        info "Creating new client config #{config_alias}" if config_section.empty?
 
         config_section["username"] = email unless config_section["username"]
 

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -12,8 +12,8 @@ module Brightbox
       # @option options [String] :auth_url
       #
       def add_section(client_alias, client_id, secret, options)
-        client_config = config[client_alias]
-        if client_config.empty?
+        config_section = config[client_alias]
+        if config_section.empty?
           info "Creating new client config #{client_alias}"
         else
           old_calias = client_alias
@@ -21,17 +21,17 @@ module Brightbox
           deduplicator = Brightbox::Config::SectionNameDeduplicator.new(client_alias, section_names)
           client_alias = deduplicator.next
           # Need to open the new config again
-          client_config = config[client_alias]
+          config_section = config[client_alias]
 
           info "A client config named #{old_calias} already exists using #{client_alias} instead"
         end
 
-        client_config["alias"] = client_alias
-        client_config["client_id"] = client_id
-        client_config["username"] = options[:username]
-        client_config["secret"] = secret
-        client_config["api_url"] = options[:api_url] || DEFAULT_API_ENDPOINT
-        client_config["auth_url"] = options[:auth_url] || client_config["api_url"]
+        config_section["alias"] = client_alias
+        config_section["client_id"] = client_id
+        config_section["username"] = options[:username]
+        config_section["secret"] = secret
+        config_section["api_url"] = options[:api_url] || DEFAULT_API_ENDPOINT
+        config_section["auth_url"] = options[:auth_url] || config_section["api_url"]
 
         dirty!
 

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -2,6 +2,64 @@ module Brightbox
   module Config
     module Sections
       #
+      # @param [String] email
+      # @param [String] password
+      # @param [Hash] options
+      # @option options [String] :alias
+      # @option options [String] :api_url
+      # @option options [String] :auth_url
+      # @option options [String] :default_account
+      # @option options [String] :client_id
+      # @option options [String] :secret
+      #
+      def add_login(email, password, options = {})
+        # If a custom alias is passed, used that for the config header, otherwise use email
+        config_alias = options[:alias] || email
+        config_section = config[config_alias]
+
+        info "Creating new client config #{email}" if config_section.empty?
+
+        config_section["username"] = email unless config_section["username"]
+
+        config_section["api_url"] = options[:api_url] if options.key?(:api_url)
+        config_section["api_url"] = DEFAULT_API_ENDPOINT unless config_section["api_url"]
+
+        config_section["auth_url"] = options[:auth_url] if options.key?(:auth_url)
+        config_section["auth_url"] = config_section["api_url"]
+
+        config_section["default_account"] = options[:default_account] if options.key?(:default_account)
+
+        config_section["client_id"] = options[:client_id] if options.key?(:client_id)
+        config_section["secret"] = options[:secret] if options.key?(:secret)
+
+        dirty!
+
+        self.client_name = client_alias
+
+        # Renew tokens via config...
+        #
+        # Part of the "login" behaviour is to always refresh them
+        #
+        begin
+          flush_access_token!
+          renew_tokens(:client_name => config_alias, :password => password)
+        rescue => e
+          error "Something went wrong trying to refresh new tokens #{e.message}"
+        end
+
+        # Try to determine a default account
+        unless default_account == find_or_set_default_account
+          info "The default account of #{default_account} has been selected"
+        end
+
+        # If only client then set it as the default
+        set_default_client(client_alias) unless default_client
+
+        # Ensure all our config changes are now saved
+        save
+      end
+
+      #
       # @param [String] client_alias
       # @param [String] client_id
       # @param [String] secret

--- a/lib/brightbox-cli/gli_global_hooks.rb
+++ b/lib/brightbox-cli/gli_global_hooks.rb
@@ -41,7 +41,7 @@ module Brightbox
     Brightbox.config = BBConfig.new(config_opts)
 
     # Commands that alter the config files should not error here
-    unless [:config].include?(command.topmost_ancestor.name)
+    unless [:config, :login].include?(command.topmost_ancestor.name)
       raise AmbiguousClientError, AMBIGUOUS_CLIENT_ERROR if Brightbox.config.client_name.nil?
 
       if Brightbox.config.has_multiple_clients?

--- a/lib/brightbox-cli/gli_global_hooks.rb
+++ b/lib/brightbox-cli/gli_global_hooks.rb
@@ -33,22 +33,28 @@ module Brightbox
   switch [:k, :insecure], :negatable => false
 
   pre do |global_options, command, _options, _args|
-    if command.topmost_ancestor.name == :config
-      force_default_config = false
-    else
-      force_default_config = true
-    end
-
     # Configuration options
     config_opts = {
-      :force_default_config => force_default_config,
       :client_name => ENV["CLIENT"] || global_options[:client],
       :account => ENV["ACCOUNT"] || global_options[:account]
     }
     Brightbox.config = BBConfig.new(config_opts)
 
-    # Outputs a snapshot of the tokens known by the client
-    Brightbox.config.debug_tokens if Brightbox.config.respond_to?(:debug_tokens)
+    # Commands that alter the config files should not error here
+    unless [:config].include?(command.topmost_ancestor.name)
+      raise AmbiguousClientError, AMBIGUOUS_CLIENT_ERROR if Brightbox.config.client_name.nil?
+
+      if Brightbox.config.has_multiple_clients?
+        if Brightbox.config.client_has_alias?
+          info "INFO: client_id: #{Brightbox.config.client_name} (#{Brightbox.config.client_alias})"
+        else
+          info "INFO: client_id: #{Brightbox.config.client_name}"
+        end
+      end
+
+      # Outputs a snapshot of the tokens known by the client
+      Brightbox.config.debug_tokens if Brightbox.config.respond_to?(:debug_tokens)
+    end
 
     Excon.defaults[:headers]['User-Agent'] = "brightbox-cli/#{Brightbox::VERSION} Fog/#{Fog::Core::VERSION}"
 
@@ -63,13 +69,6 @@ module Brightbox
       Hirb::View.resize
     end
 
-    if Brightbox.config.has_multiple_clients?
-      if Brightbox.config.client_has_alias?
-        info "INFO: client_id: #{Brightbox.config.client_id} (#{Brightbox.config.client_alias})"
-      else
-        info "INFO: client_id: #{Brightbox.config.client_id}"
-      end
-    end
     true
   end
 

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_false/does_not_update_the_config_file.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_false/does_not_update_the_config_file.yml
@@ -1,0 +1,199 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"46fbbfb8a2a2a7ac18ddeb0827caecd5"'
+      X-Request-Id:
+      - f023fab1e85e0bfa6dd2047ba00a56e2
+      X-Runtime:
+      - '0.089060'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:34:22 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"64f68b5dddea1c6b774286180375ba883b896cac","token_type":"Bearer","refresh_token":"b7716ed2480d2831c8cb8af8ea536666c27815b1","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 64f68b5dddea1c6b774286180375ba883b896cac
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"79022220a299b096df8561e8b08c2a6c"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - d9bf84944cdefeb0ad6eec2208adb07b
+      X-Runtime:
+      - '0.115969'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:34:22 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"b7716ed2480d2831c8cb8af8ea536666c27815b1"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"dd8fd24413fcd0a0a60481951e332374"'
+      X-Request-Id:
+      - e937501889b560dac744be408f920d6b
+      X-Runtime:
+      - '0.044393'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:34:22 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"c8975689c865aafc885cf964a76fa72418451e25","token_type":"Bearer","refresh_token":"9f7921dbea20637a80b117f3e677060831b6522d","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer c8975689c865aafc885cf964a76fa72418451e25
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"79022220a299b096df8561e8b08c2a6c"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a1371291bf1482c522f967fff0d1b86f
+      X-Runtime:
+      - '0.044154'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:34:22 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_true/does_not_update_the_config_file.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_true/does_not_update_the_config_file.yml
@@ -1,0 +1,199 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"2a4be747fd46075bcb395a242ed76253"'
+      X-Request-Id:
+      - dd49f50cea13daa0e840b1ed350b06cf
+      X-Runtime:
+      - '0.089367'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:55:23 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"13824deca216ba81d5963d75659755d76083c490","token_type":"Bearer","refresh_token":"6b70b12f95df7b7e95e6cf0a99e5982ea7087f2c","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 13824deca216ba81d5963d75659755d76083c490
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"79022220a299b096df8561e8b08c2a6c"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9f7629fdd50646311d4cb022dfd867c4
+      X-Runtime:
+      - '0.116434'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:55:23 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"6b70b12f95df7b7e95e6cf0a99e5982ea7087f2c"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"42b98dac6f17fff4a57b51c71f165c16"'
+      X-Request-Id:
+      - 5d1c861531e840a9462d3b33ee81f1ee
+      X-Runtime:
+      - '0.025472'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:55:23 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9f1758514b2245dc6d52c550d252074287277e7b","token_type":"Bearer","refresh_token":"514aa63f8de3113429e721e117cc60f5a6e2e004","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 9f1758514b2245dc6d52c550d252074287277e7b
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"79022220a299b096df8561e8b08c2a6c"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 88733c18e03e378dbe83da0b01468469
+      X-Runtime:
+      - '0.044765'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Wed, 30 Sep 2015 14:55:23 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/does_not_alter_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/does_not_alter_the_configuration.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"2c8c8a9c75e455aadba195f637dd03b5"'
+      X-Request-Id:
+      - 85bf94b4475854b507ad53ea76e68c10
+      X-Runtime:
+      - '0.086533'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"d3d51356b662040aa9b0e4bf162409b4ea879aab","token_type":"Bearer","refresh_token":"7c72c3b5d05b61b21e9795919b236c1563496a40","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"7c72c3b5d05b61b21e9795919b236c1563496a40"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"3196dc26509b1f0f2d24a255c9351190"'
+      X-Request-Id:
+      - 462487ff1da08ce3f3aa79a9ad80d8b7
+      X-Runtime:
+      - '0.112980'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9007643d343038066570caa040c929d19a9826e1","token_type":"Bearer","refresh_token":"a6403aaf3bc717aeadeae2f78bf8182bdd6e565e","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_access_token.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c43da9a9c80ef59a8d02f590bd9f3a4c"'
+      X-Request-Id:
+      - a4db8c442ec6d60cf483004174488c76
+      X-Runtime:
+      - '0.088459'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9aa043fa1343df86b7288c405d077674faf5943b","token_type":"Bearer","refresh_token":"4ce512422f6551fe7358aba6781c9c2270486805","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"4ce512422f6551fe7358aba6781c9c2270486805"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"0c6c13495dda671e1544894a7cb90d17"'
+      X-Request-Id:
+      - 2ecfd488a85a7ce94db14a6fe2f3ddd8
+      X-Runtime:
+      - '0.027900'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"2eea36047cea590f963d5ac76e6a73d8e62e9738","token_type":"Bearer","refresh_token":"34019e0aaf024580dd0e4c46f81113b39e191085","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_refresh_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_refresh_token.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"e3a730b016d8921bce663a9f76fd35e2"'
+      X-Request-Id:
+      - 918e8456edb69e1c822b7fc6e765f0a9
+      X-Runtime:
+      - '0.087545'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"7511af8bbea2b6f214fc358d9aef90f4b31702e3","token_type":"Bearer","refresh_token":"87ee62bc09a7fe69e96c8c07fd61c9c9019de180","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"87ee62bc09a7fe69e96c8c07fd61c9c9019de180"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"55ed6f75677bf4d114067ede68a3037e"'
+      X-Request-Id:
+      - 58f3a21952f2c8bbc3ea69495526ab0d
+      X-Runtime:
+      - '0.115984'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"fe0c22e0855f692a06bfdf712ec2508e2e5b1d24","token_type":"Bearer","refresh_token":"ea1a800fd63fec3b8ff2dc9b96837fe68a54a928","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/does_not_alter_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/does_not_alter_the_configuration.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"ceeca54433f782f74bc8b1c579e7534a"'
+      X-Request-Id:
+      - e48b1225e36360768214e968e2214d9f
+      X-Runtime:
+      - '0.086998'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"2a0dc3e96bb4c077b71425e5f20a7fe4323cb967","token_type":"Bearer","refresh_token":"581e7ac10e16b21a6375503509b55c183c6f52ce","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"581e7ac10e16b21a6375503509b55c183c6f52ce"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"0639b5e2dcc558804e536e8b61dc00f0"'
+      X-Request-Id:
+      - 8ad84f6e26844dbd42963a6f554a8833
+      X-Runtime:
+      - '0.029192'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"55e733e1e4f06bb8dcca957409b2ec4edeadba44","token_type":"Bearer","refresh_token":"27fb8e6765cd6987710d6044d9745ce735a5cb14","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_access_token.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"3344f6a760efbdffed86276ddb598d7d"'
+      X-Request-Id:
+      - 34396ff1215e9f3ea17728e36ed65215
+      X-Runtime:
+      - '0.090665'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"bd7acf61bdbad602e74951f62102cd0d61532277","token_type":"Bearer","refresh_token":"8a53a8103f3e90fc9b895f3afb34d875cba18c0b","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"8a53a8103f3e90fc9b895f3afb34d875cba18c0b"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"4fadaa56844504ec9395da0dd93cf3ca"'
+      X-Request-Id:
+      - afc83603da662336a240b76afea29326
+      X-Runtime:
+      - '0.112833'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"437d4e29c60acf9b2f08cff31bc384c48ae2d1a4","token_type":"Bearer","refresh_token":"25980c2a6eb9a834bb4d42ea16b902ef7dd3b651","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_refresh_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_refresh_token.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"1dbe6769e31cd2c7b0983d5d152b3a88"'
+      X-Request-Id:
+      - 15e23e2c255bad4655876f6bd4607bd8
+      X-Runtime:
+      - '0.088547'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"aa418baea89052f46b3a64e6f70808ee74ef3edb","token_type":"Bearer","refresh_token":"7576198c29eb4bef281c9c37d367dc93682c98d0","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"7576198c29eb4bef281c9c37d367dc93682c98d0"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTIzNDU2OmhvMDRob25kdHpqamRmNA==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"20b602f213eb4a58926abe79390ef4a1"'
+      X-Request-Id:
+      - ccbe521bfb7a364fe4c73c843674ebab
+      X-Runtime:
+      - '0.028544'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:20 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"c050b5cf9e9dceb65892a7d492518cfb0ff0e912","token_type":"Bearer","refresh_token":"7b88a20eb4a1e5efb66daa809202ccca4a6b0dc1","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/does_not_alter_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/does_not_alter_the_configuration.yml
@@ -1,0 +1,149 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"2967bf86ef2ec53c6509ad399bd05449"'
+      X-Request-Id:
+      - b8989b75b8fe14eaa9efef073ae7cf8a
+      X-Runtime:
+      - '0.087711'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"fb2b511bc41324b7661ff36a7147218f9c8fdd7d","token_type":"Bearer","refresh_token":"d6e06d34b77c525ebbd4d5ac10156c71461be803","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer fb2b511bc41324b7661ff36a7147218f9c8fdd7d
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5a0d2b349506a9fada00baf6f5028138
+      X-Runtime:
+      - '0.131382'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"d6e06d34b77c525ebbd4d5ac10156c71461be803"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"0a2e9b7ac7a502a7efb7cc832559f3a9"'
+      X-Request-Id:
+      - 24ea016dfbb73a4e6c57e6e884c26adc
+      X-Runtime:
+      - '0.028314'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"ff8ee8c3ec7e5d2b56bd8a0b278fe7fe2957c760","token_type":"Bearer","refresh_token":"054b814f6c87c6867389468e71563822beb102ed","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_access_token.yml
@@ -1,0 +1,149 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"05b192d504f0d94d4995c9cb4bfabfa8"'
+      X-Request-Id:
+      - c17c01b900e70f25e08aefcc216a5d2e
+      X-Runtime:
+      - '0.087341'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"ba308ca0d6c436138d08273efb3e4dcc94316c29","token_type":"Bearer","refresh_token":"3aac6c150ea7b2712df3134375359ced3ab18a64","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer ba308ca0d6c436138d08273efb3e4dcc94316c29
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 011afd81a94d3fd5ea940c33bfd34094
+      X-Runtime:
+      - '0.127058'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"3aac6c150ea7b2712df3134375359ced3ab18a64"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"564a6f51dcf72e648fa9f3eabda76782"'
+      X-Request-Id:
+      - 1eaca0794131c9dde141e8ff95e747d2
+      X-Runtime:
+      - '0.030053'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"9ce76a11968b0945fef107e70e21e0224d1eb8c6","token_type":"Bearer","refresh_token":"f54a157a62fd86c8b6be7458c8dcd91875d0831d","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_refresh_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_refresh_token.yml
@@ -1,0 +1,149 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"5f6df8f4d6157a3b4d0a0bd4cc00ead7"'
+      X-Request-Id:
+      - f672ea5b57d864b3069656641ee475f1
+      X-Runtime:
+      - '0.089046'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"3b80108be0152c2d31575574027de1b9807fc971","token_type":"Bearer","refresh_token":"536bd861231e153f11893399ecbb6b417adbb0a3","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 3b80108be0152c2d31575574027de1b9807fc971
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 910c44324fab4884324db6d454e8576b
+      X-Runtime:
+      - '0.043977'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"refresh_token","refresh_token":"536bd861231e153f11893399ecbb6b417adbb0a3"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"cd0a6430291fc349fd03eb6642dd392c"'
+      X-Request-Id:
+      - a2cacbb41cf130c43c404700ef352e3f
+      X-Runtime:
+      - '0.111505'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:19 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"73e0ea46b6067aaba435ef21ac0c9f18b185a162","token_type":"Bearer","refresh_token":"8de93966cb2092de010c68939cb2da3aac74924e","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/creates_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/creates_the_configuration.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"52cf652e4c8197b06a5df541b6c6e6b6"'
+      X-Request-Id:
+      - c41fe56cfea4d84c928af11c4ad27b60
+      X-Runtime:
+      - '0.086987'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"cd64dd737e020f9975a97c35e78e27e46442eb27","token_type":"Bearer","refresh_token":"00114bd8f6aa955911870efbb5f8b135dc6fc9c5","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer cd64dd737e020f9975a97c35e78e27e46442eb27
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f4dde3adcaecea5e4df8f56927b328b5
+      X-Runtime:
+      - '0.044869'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/refreshed_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/refreshed_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"7c6c299200a760215ff6d635fbfb87fa"'
+      X-Request-Id:
+      - 25a83af3475513c26604a8e675a2694f
+      X-Runtime:
+      - '0.169489'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"f1d7a05784f9bea5060fbcc4a9a46d5b6cf05dbe","token_type":"Bearer","refresh_token":"5b891e0affc1fa7d9e5462482e07f6bf3c0ad21f","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer f1d7a05784f9bea5060fbcc4a9a46d5b6cf05dbe
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bec97c1b2f65ab03e869ba79280b3f0c
+      X-Runtime:
+      - '0.045946'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/creates_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/creates_the_configuration.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"52cf652e4c8197b06a5df541b6c6e6b6"'
+      X-Request-Id:
+      - c41fe56cfea4d84c928af11c4ad27b60
+      X-Runtime:
+      - '0.086987'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"cd64dd737e020f9975a97c35e78e27e46442eb27","token_type":"Bearer","refresh_token":"00114bd8f6aa955911870efbb5f8b135dc6fc9c5","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer cd64dd737e020f9975a97c35e78e27e46442eb27
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f4dde3adcaecea5e4df8f56927b328b5
+      X-Runtime:
+      - '0.044869'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/refreshed_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/refreshed_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"7c6c299200a760215ff6d635fbfb87fa"'
+      X-Request-Id:
+      - 25a83af3475513c26604a8e675a2694f
+      X-Runtime:
+      - '0.169489'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"f1d7a05784f9bea5060fbcc4a9a46d5b6cf05dbe","token_type":"Bearer","refresh_token":"5b891e0affc1fa7d9e5462482e07f6bf3c0ad21f","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer f1d7a05784f9bea5060fbcc4a9a46d5b6cf05dbe
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bec97c1b2f65ab03e869ba79280b3f0c
+      X-Runtime:
+      - '0.045946'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 11:34:18 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"8427a5b33563d107f36f432b571b1aea"'
+      X-Request-Id:
+      - a69ad322d55ff6ef493a47eca023909d
+      X-Runtime:
+      - '0.087780'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 44320b29286077c44f14c4efdfed70f63f4a8361
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 673b66619adee67e28f49368f32c6ffa
+      X-Runtime:
+      - '0.126722'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"89f175c34bfcea4f13ca83f4e28948e1"'
+      X-Request-Id:
+      - 5cc0625f0d653ed56648aa58eb0b912f
+      X-Runtime:
+      - '0.087828'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:54 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"f04583a23a52ebd80898bafd1e1025327fb97544","token_type":"Bearer","refresh_token":"b8efc70e9ab697d2ac19bb54efabf317239bb246","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer f04583a23a52ebd80898bafd1e1025327fb97544
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3a7e02d34f671a05919ada58ce47eb5c
+      X-Runtime:
+      - '0.125844'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:54 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"8ee14672175020dbbb988fe0623ff19a"'
+      X-Request-Id:
+      - 1f42116179b87819053cc6860dfb1fd3
+      X-Runtime:
+      - '0.171759'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"12249a52a3f5d7aa4912764e6e5d70c78ff664f3","token_type":"Bearer","refresh_token":"3b3245e1cdc86dfab023a80755c7d07c56c4d16e","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 12249a52a3f5d7aa4912764e6e5d70c78ff664f3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1c2c9d198c6200ba54dd8bbb4deaf74d
+      X-Runtime:
+      - '0.045588'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"83e745f60b53dd59c18d345a33ba61dd"'
+      X-Request-Id:
+      - facf28b9c514be4a55e55964e7c3a4bd
+      X-Runtime:
+      - '0.170048'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:54 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"67ba17bf0f2c8c8b5fbcdd27745ded8c8acd75a1","token_type":"Bearer","refresh_token":"7d0559c8de7546463a7fb3e608e234ba4b980aff","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 67ba17bf0f2c8c8b5fbcdd27745ded8c8acd75a1
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ad87366e92ce11bd3dd96c53cd4dc77c
+      X-Runtime:
+      - '0.045671'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:54 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"4c6305171eb034617f74e513e2cf77a7"'
+      X-Request-Id:
+      - 44702d958126ab7bc04ce5e380f36bdb
+      X-Runtime:
+      - '0.089354'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"c8038e9c15ef8c53dcf1c746944c09283ad95c3b","token_type":"Bearer","refresh_token":"1e36d9917dc7ecfcbae82b35711746ceecbd602f","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer c8038e9c15ef8c53dcf1c746944c09283ad95c3b
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 813c1093305858464f5f6e3bd26e7e85
+      X-Runtime:
+      - '0.045726'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"0c187be7c32a4e07d5ba8e4941f8cb23"'
+      X-Request-Id:
+      - 3df44cf01874a87583b07e45c05e972d
+      X-Runtime:
+      - '0.090117'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"007db0c2d5319fe5c1699d77e41e3a279c53ff26","token_type":"Bearer","refresh_token":"6011155876a84e5a18f76522b8cec0d5bd95b936","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 007db0c2d5319fe5c1699d77e41e3a279c53ff26
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 0b74f8782db16178888090c0ff65c87f
+      X-Runtime:
+      - '0.048228'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"07327efef8081c3646b3e15bc0109f24"'
+      X-Request-Id:
+      - 2b0d7c3ef5a6ca9350bf224c49f8d228
+      X-Runtime:
+      - '0.087681'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"e4d0e860186948c4fe5d46f6637e2d64f3d75a0b","token_type":"Bearer","refresh_token":"4ee0543818f24cc945944b30c7365a2995d3c467","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer e4d0e860186948c4fe5d46f6637e2d64f3d75a0b
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 81076b505b40bac2fbced1b019efcc58
+      X-Runtime:
+      - '0.046246'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"b184fe6f9beecf62178e8ca840a3b68a"'
+      X-Request-Id:
+      - bb173ed2ba64ab7c8ab22edf7f23f680
+      X-Runtime:
+      - '0.089382'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"e494b869f62c6d21d4fede766f4f33936ee3e50c","token_type":"Bearer","refresh_token":"1d69d988bc9fde48171ce7a90a2c141364e9781d","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer e494b869f62c6d21d4fede766f4f33936ee3e50c
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ba1d235f2c79f7e84e0b666cb39fa3a1
+      X-Runtime:
+      - '0.129332'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"ab0001e60be068e6ddb5c711fbda4e0c"'
+      X-Request-Id:
+      - ea74db5e02a444732d675a7ef24bea12
+      X-Runtime:
+      - '0.092380'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"97f06bbe4ad27cca54d8f654f713458456d9f8e0","token_type":"Bearer","refresh_token":"e120ddcb3f6ed618cf3b4420b9c5d1e6f1557965","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 97f06bbe4ad27cca54d8f654f713458456d9f8e0
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9f0bf27e5fb8ff7cfb40d3e014a30349
+      X-Runtime:
+      - '0.131785'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"414b925cd8111cf5e7554c69cc901075"'
+      X-Request-Id:
+      - 998b40c09fbb530cbbb6bb35c5cbbfdb
+      X-Runtime:
+      - '0.170053'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"def6238f30ac65ee3f3aae7d61e39f17a3fcf9fd","token_type":"Bearer","refresh_token":"4e8bbe751340be8e33e336e83d9e3f18fbdb5587","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer def6238f30ac65ee3f3aae7d61e39f17a3fcf9fd
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 981e198b3decea2f8de71692e9f82885
+      X-Runtime:
+      - '0.046297'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_error.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"a16c9b8526ee6e4669e82b455a69e8a7"'
+      X-Request-Id:
+      - 31b0bf6392a4dc38014a9b7a60651b1c
+      X-Runtime:
+      - '0.089294'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"a5dcbaa16f20832bc6df0b709efacc624cd7e58b","token_type":"Bearer","refresh_token":"6577ac9f6c4c1176fd82b0eaf1dacc207b37f496","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"7df478da10966a7cb72fa10f399716cb"'
+      X-Request-Id:
+      - c4345675cdc991a05f79cf1681bf13fd
+      X-Runtime:
+      - '0.087381'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"070f61decf530b8159aa75d80e61fc0c157b1efb","token_type":"Bearer","refresh_token":"b2073600848dd5fa6ea69115dd96730330190fb3","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/prompts_for_the_password.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"fa3845918ffb7d84a78127e5df396c48"'
+      X-Request-Id:
+      - f33d8feeecca56adcc0004fc3bf90171
+      X-Runtime:
+      - '0.178754'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:52 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"cf9042dc6082feee0390b00cdb4e6a0c08f74ca3","token_type":"Bearer","refresh_token":"0977441e798173b94028b76eaf6bcb6e08dafc8e","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/requests_access_tokens.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"1a46df03e9abec9d52037c2a6bf2bfbd"'
+      X-Request-Id:
+      - ed3b7f46d7e3ddc63672ee422c87e57f
+      X-Runtime:
+      - '0.089019'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"a64a130f3a6f32529e539b3b0ba9cb0bd829160d","token_type":"Bearer","refresh_token":"c2239ef492e6d13d95c04e1f2ab7d99b16e0c202","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/sets_up_the_config.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"cfd6ec3349977a04bb9c8336f4322a5b"'
+      X-Request-Id:
+      - e64625fb0bd10945460712e70048ad67
+      X-Runtime:
+      - '0.088462'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:53 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"a555fa363cb14838b2efc870494ec6aa2360808b","token_type":"Bearer","refresh_token":"1a27aae58a7f3f185cb8fa75a0a150a3504a8606","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"6652ec9e77033d7422d201c370226350"'
+      X-Request-Id:
+      - 7172bd9f9890d209834fd14f071047f6
+      X-Runtime:
+      - '0.090607'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:49 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"17e9282e40b8a2f1366107a068a1632bb65d3dec","token_type":"Bearer","refresh_token":"b77913a13cccfdd44294b4b161494a652d48b635","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:49 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 17e9282e40b8a2f1366107a068a1632bb65d3dec
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8e143bd22e4fed15e9df60b3e631ecee
+      X-Runtime:
+      - '0.124907'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"677cbfbe978882708a0fea42b49fc44f"'
+      X-Request-Id:
+      - 6b5f7de4af6c82c7bca88c6ece9307c6
+      X-Runtime:
+      - '0.087576'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"a417c4c77d6c301799fd36a8056d5d806186cc60","token_type":"Bearer","refresh_token":"20c5df44e08169d0abfa0bca6de921a37d81c5ce","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer a417c4c77d6c301799fd36a8056d5d806186cc60
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 301110e1e1e34aaa018ae66e600b57b0
+      X-Runtime:
+      - '0.129328'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d3770d0e4fe4a5c71659f96b6798259c"'
+      X-Request-Id:
+      - 10717b4d54e14079d9e1ce9b368785a0
+      X-Runtime:
+      - '0.088961'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"4e7c8dd40b841b806583f5b2cadcc691ab15be46","token_type":"Bearer","refresh_token":"da0effede233897c05dabe2924c39be9011012b7","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 4e7c8dd40b841b806583f5b2cadcc691ab15be46
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b466683fe040cabcff4dde524953258c
+      X-Runtime:
+      - '0.126882'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"e140941ca338a8e115aacec6ae73bebc"'
+      X-Request-Id:
+      - 9d5b7635e12abad5e07441473f08f345
+      X-Runtime:
+      - '0.087628'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"affffc3b0161b9255914aaf4f598a15aa010df3f","token_type":"Bearer","refresh_token":"152ab03cbf105485a5a1ff64b189beeaff9cfad9","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer affffc3b0161b9255914aaf4f598a15aa010df3f
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a7ab7d38d6e403cf35383e1904e3b9f1
+      X-Runtime:
+      - '0.045832'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_error.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"8279d22fcea6fbc78fe4d5b6401c7bd8"'
+      X-Request-Id:
+      - 8f92505cc0877e00cf16b5f5ed5eb105
+      X-Runtime:
+      - '0.090429'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"04e476fd543f333dc007196d76a6625d6570adf7","token_type":"Bearer","refresh_token":"2cafee59e2c2d6cf847c83161870351792376b6b","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 04e476fd543f333dc007196d76a6625d6570adf7
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2fb3fee3dda4c0c3fbc100c73d17d3d8
+      X-Runtime:
+      - '0.127427'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_prompt_to_rerun_the_command.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"6910c5838277ed607f75094ff0db29b1"'
+      X-Request-Id:
+      - b3d8641c1afcbd8571eb0d796617b461
+      X-Runtime:
+      - '0.087888'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"40b90180f48c7a3c6638f8175e2a34cc73b03b0f","token_type":"Bearer","refresh_token":"18b68b787ac0e33ad14c51eb7fbf5af1f4dc0ab2","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 40b90180f48c7a3c6638f8175e2a34cc73b03b0f
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1de7a1cccf5db493f3e9a54ac83b836d
+      X-Runtime:
+      - '0.043561'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/prompts_for_the_password.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"a673efcf5231e077ec0d5835a8259297"'
+      X-Request-Id:
+      - 1dc22eb11b7f927860c5ee68d2e9ca7b
+      X-Runtime:
+      - '0.089194'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"b7e97a2c08221216f6f82ee05e1d9631446853bb","token_type":"Bearer","refresh_token":"7d845e3d6790e2888a36922302bdaf42c59207e7","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer b7e97a2c08221216f6f82ee05e1d9631446853bb
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8f65d4d33c3abd48e1c236af65e5844e
+      X-Runtime:
+      - '0.045444'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:50 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/requests_access_tokens.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"03a2f5ef6ee075450f1823c2eb312874"'
+      X-Request-Id:
+      - c18a04b5e0ecf421a517d40e66a7cf39
+      X-Runtime:
+      - '0.090494'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"0e2b6ecb38dc7edeecd010fdbb130dc81eed3244","token_type":"Bearer","refresh_token":"84e7fbdaee8490c190fcadb0d6e514bb0dd28f7b","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer 0e2b6ecb38dc7edeecd010fdbb130dc81eed3244
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b4645084926cf99f30046e0441fbcf6f
+      X-Runtime:
+      - '0.048355'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/sets_up_the_config.yml
@@ -1,0 +1,101 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.dev/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      Content-Type:
+      - application/json
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Length:
+      - '190'
+      X-Content-Type-Options:
+      - nosniff
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"d942cf5e51cc86fde5b2a75984557ca9"'
+      X-Request-Id:
+      - 41f8efe24820a636ee030168b905eb90
+      X-Runtime:
+      - '0.087310'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"b07faf14eafa2fd510bb7ef94aff0acfaaa3c70f","token_type":"Bearer","refresh_token":"83aa5702840aba673845a9b9bd35421065eb4d8f","scope":"infrastructure,
+        orbit","expires_in":7200}'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.dev/1.0/accounts
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.1
+      Authorization:
+      - Bearer b07faf14eafa2fd510bb7ef94aff0acfaaa3c70f
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Content-Type:
+      - application/json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - '"c9a269456e92ca15ff834e08ba6414ad"'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - b168c47f4374123523356a9760242b31
+      X-Runtime:
+      - '0.127805'
+      Server:
+      - WEBrick/1.3.1 (Ruby/1.9.3/2014-11-13)
+      Date:
+      - Mon, 12 Oct 2015 14:53:51 GMT
+      Content-Length:
+      - '1611'
+      Connection:
+      - Keep-Alive
+    body:
+      encoding: UTF-8
+      string: '[{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active","ram_limit":3200000,"ram_used":0,"dbs_ram_limit":32768,"dbs_ram_used":0,"cloud_ips_limit":32,"cloud_ips_used":0,"load_balancers_limit":5,"load_balancers_used":0,"clients":[{"id":"cli-12345","resource_type":"api_client","url":"https://api.gb1.brightbox.com/1.0/api_clients/cli-12345","name":"CLI
+        test API client","description":"","revoked_at":null,"permissions_group":"full"}],"images":[],"servers":[],"load_balancers":[],"database_servers":[],"database_snapshots":[],"cloud_ips":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.gb1.brightbox.com/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
+        to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
+        Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
+    http_version: 
+  recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
+recorded_with: VCR 2.5.0

--- a/spec/commands/accounts/list_spec.rb
+++ b/spec/commands/accounts/list_spec.rb
@@ -60,6 +60,7 @@ describe "brightbox accounts" do
 
       before do
         config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+        #mock_password_entry(password)
 
         # Setup in the VCR recordings as the access token is expired
         cache_access_token(config, "08f204123bb2fc400521577445df9d1d212da42e")

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -152,7 +152,7 @@ describe "brightbox login" do
 
   context "when default account is passed", vcr: true do
     let(:account) { "acc-23456" }
-    let(:argv) { ["login", "--account", account, email] }
+    let(:argv) { ["login", "--default-account", account, email] }
 
     before do
       remove_config

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -1,0 +1,239 @@
+require "spec_helper"
+
+describe "brightbox login" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  let(:email) { "jason.null@brightbox.com" }
+  let(:password) { "N:B3e%7Cmh" }
+  let(:client_id) { "app-12345" }
+  let(:secret) { "mocbuipbiaa6k6c" }
+  let(:api_url) { "http://api.brightbox.dev" }
+
+  let(:default_account) { "acc-12345" }
+  let(:client_alias) { email }
+
+  context "when no arguments are given" do
+    let(:argv) { %w(login) }
+
+    it "errors prompting for the email address" do
+      remove_config
+      expect(stderr).to include("You must specify your email address")
+    end
+  end
+
+  context "when no config is present", vcr: true do
+    let(:argv) { ["login", "-p", password, email] }
+
+    before do
+      remove_config
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["username"]).to eql(email)
+      expect(@client_section["default_account"]).to eql(default_account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+
+  context "when no password is given", vcr: true do
+    let(:argv) { ["login", email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["username"]).to eql(email)
+      expect(@client_section["default_account"]).to eql(default_account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+
+  context "when custom api/auth URLs are given", vcr: true do
+    # FIXME: These need to be the "real" defaults to record the token interchange
+    #        May allow a regression that the defaults are used, not the passed argument
+    #        Need to use something better that VCR.
+    let(:api_url) { Brightbox::DEFAULT_API_ENDPOINT }
+    let(:auth_url) { Brightbox::DEFAULT_API_ENDPOINT }
+    let(:argv) { ["login", "--api-url", api_url, "--auth-url", auth_url, email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["auth_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["username"]).to eql(email)
+      expect(@client_section["default_account"]).to eql(default_account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+
+  context "when default account is passed", vcr: true do
+    let(:account) { "acc-23456" }
+    let(:argv) { ["login", "--account", account, email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["api_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["auth_url"]).to eql(Brightbox::DEFAULT_API_ENDPOINT)
+      expect(@client_section["username"]).to eql(email)
+      expect(@client_section["default_account"]).to eql(account)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+
+  context "when alternative client credentials are given", vcr: true do
+    let(:other_client_identifier) { "app-23456" }
+    let(:other_client_secret) { "ho04hondtzjjdf4" }
+    let(:argv) { ["login", "--application-id", other_client_identifier, "--application-secret", other_client_secret, email] }
+
+    before do
+      remove_config
+      mock_password_entry(password)
+    end
+
+    it "prompts for the password" do
+      expect { output }.not_to raise_error
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+      expect(stderr).to_not include("ERROR")
+    end
+
+    it "sets up the config" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new
+      @client_section = @config.config[email]
+
+      expect(@client_section["client_id"]).to eql(other_client_identifier)
+      expect(@client_section["secret"]).to eql(other_client_secret)
+    end
+
+    it "requests access tokens" do
+      expect { output }.to_not raise_error
+
+      @config = Brightbox::BBConfig.new :client_name => email
+
+      expect(cached_access_token(@config)).to eql(@config.access_token)
+      expect(cached_refresh_token(@config)).to eql(@config.refresh_token)
+    end
+
+    it "does not prompt to rerun the command" do
+      expect(stderr).to_not include("please re-run your command")
+    end
+  end
+end

--- a/spec/support/config_helpers.rb
+++ b/spec/support/config_helpers.rb
@@ -16,6 +16,8 @@ module ConfigHelpers
       f.write contents
     end
 
+    config = Brightbox::BBConfig.new
+
     # Subvert the global
     Brightbox.config = config
 

--- a/spec/unit/brightbox/bb_config/account_spec.rb
+++ b/spec/unit/brightbox/bb_config/account_spec.rb
@@ -35,6 +35,8 @@ describe Brightbox::BBConfig do
         @account_name = "acc-ghj32"
         @client_name = "app-b3n5b"
         contents = <<-EOS
+        [core]
+        default_client = #{@client_name}
         [#{@client_name}]
         default_account = #{@account_name}
         EOS

--- a/spec/unit/brightbox/bb_config/add_login_spec.rb
+++ b/spec/unit/brightbox/bb_config/add_login_spec.rb
@@ -181,4 +181,42 @@ EOS
       end
     end
   end
+
+  context "when using an email and suffix", vcr: true do
+    let(:client_name) { "#{email}/dev" }
+    let(:expected_config) do
+      <<EOS
+[core]
+default_client = #{client_name}
+
+[#{client_name}]
+username = #{email}
+api_url = #{api_url}
+auth_url = #{api_url}
+default_account = acc-12345
+
+EOS
+    end
+
+    before do
+      remove_config
+    end
+
+    it "creates the configuration" do
+      FauxIO.new do
+        config.add_login(client_name, password)
+      end
+      expect(config_file_contents).to eq(expected_config)
+    end
+
+    it "refreshed tokens" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.not_to raise_error
+      end
+
+      expect(cached_access_token(config)).to eq(config.access_token)
+      expect(cached_refresh_token(config)).to eq(config.refresh_token)
+    end
+  end
+
 end

--- a/spec/unit/brightbox/bb_config/add_login_spec.rb
+++ b/spec/unit/brightbox/bb_config/add_login_spec.rb
@@ -1,0 +1,184 @@
+require "spec_helper"
+
+describe Brightbox::BBConfig, "#add_login" do
+  let(:config) { Brightbox::BBConfig.new }
+
+  let(:email) { "jason.null@brightbox.com" }
+  let(:password) { "N:B3e%7Cmh" }
+  let(:api_url) { ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev" }
+
+  context "when no config exists", vcr: true do
+    let(:expected_config) do
+      <<EOS
+[core]
+default_client = #{email}
+
+[#{email}]
+username = #{email}
+api_url = #{api_url}
+auth_url = #{api_url}
+default_account = acc-12345
+
+EOS
+    end
+
+    before do
+      remove_config
+    end
+
+    it "creates the configuration" do
+      FauxIO.new do
+        config.add_login(email, password)
+      end
+      expect(config_file_contents).to eq(expected_config)
+    end
+
+    it "refreshed tokens" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.not_to raise_error
+      end
+
+      expect(cached_access_token(config)).to eq(config.access_token)
+      expect(cached_refresh_token(config)).to eq(config.refresh_token)
+    end
+  end
+
+  context "when logged in previously", vcr: true do
+    let(:original_config) { config_file_contents }
+
+    before do
+      FauxIO.new { config.add_login(email, password) }
+    end
+
+    it "does not alter the configuration" do
+      FauxIO.new do
+        expect {
+          config.add_login(email, password)
+        }.not_to change { config_file_contents }.from(original_config)
+      end
+    end
+
+    it "updates access token" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.to change {
+          config.access_token
+        }.from(cached_access_token(config))
+      end
+    end
+
+    it "updates refresh token" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.to change {
+          config.refresh_token
+        }.from(cached_refresh_token(config))
+      end
+    end
+  end
+
+  context "when configured with custom options", vcr: true do
+    let(:original_config) { config_file_contents }
+
+    let(:custom_url) { ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev" }
+    let(:custom_app_id) { "app-23456" }
+    let(:custom_app_secret) { "ho04hondtzjjdf4" }
+    let(:custom_default_account) { "acc-23456" }
+
+    let(:custom_options) do
+      {
+        api_url: custom_url,
+        auth_url: custom_url,
+        default_account: custom_default_account,
+        client_id: custom_app_id,
+        secret: custom_app_secret
+      }
+    end
+
+    before do
+      FauxIO.new { config.add_login(email, password, custom_options) }
+    end
+
+    it "does not alter the configuration" do
+      FauxIO.new do
+        expect {
+          config.add_login(email, password)
+        }.not_to change { config_file_contents }.from(original_config)
+      end
+
+      expect(config_file_contents).to match("[#{email}]")
+      expect(config_file_contents).to match("api_url = #{custom_url}")
+      expect(config_file_contents).to match("auth_url = #{custom_url}")
+      expect(config_file_contents).to match("username = #{email}")
+      expect(config_file_contents).to match("default_account = #{custom_default_account}")
+      expect(config_file_contents).to match("default_client = #{email}")
+    end
+
+    it "updates access token" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.to change {
+          config.access_token
+        }.from(cached_access_token(config))
+      end
+    end
+
+    it "updates refresh token" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.to change {
+          config.refresh_token
+        }.from(cached_refresh_token(config))
+      end
+    end
+  end
+
+  context "when altering a custom option", vcr: true do
+    let(:original_config) { config_file_contents }
+
+    let(:custom_url) { ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev" }
+    let(:custom_app_id) { "app-23456" }
+    let(:custom_app_secret) { "ho04hondtzjjdf4" }
+    let(:custom_default_account) { "acc-23456" }
+
+    let(:custom_options) do
+      {
+        api_url: custom_url,
+        auth_url: custom_url,
+        default_account: custom_default_account,
+        client_id: custom_app_id,
+        secret: custom_app_secret
+      }
+    end
+
+    before do
+      FauxIO.new { config.add_login(email, password, custom_options) }
+    end
+
+    it "does not alter the configuration" do
+      FauxIO.new do
+        expect {
+          config.add_login(email, password)
+        }.not_to change { config_file_contents }.from(original_config)
+      end
+
+      expect(config_file_contents).to match("[#{email}]")
+      expect(config_file_contents).to match("api_url = #{custom_url}")
+      expect(config_file_contents).to match("username = #{email}")
+      expect(config_file_contents).to match("default_account = #{custom_default_account}")
+      expect(config_file_contents).to match("default_client = #{email}")
+    end
+
+    it "updates access token" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.to change {
+          config.access_token
+        }.from(cached_access_token(config))
+      end
+    end
+
+    it "updates refresh token" do
+      FauxIO.new do
+        expect { config.add_login(email, password) }.to change {
+          config.refresh_token
+        }.from(cached_refresh_token(config))
+      end
+    end
+  end
+end

--- a/spec/unit/brightbox/bb_config/client_name_spec.rb
+++ b/spec/unit/brightbox/bb_config/client_name_spec.rb
@@ -56,39 +56,31 @@ describe Brightbox::BBConfig do
         [cli-12345]
         client_id = cli-12345
         EOS
-        @tmp_config = TmpConfig.new(contents)
-      end
-
-      after do
-        @tmp_config.close
+        config_from_contents(contents)
       end
 
       context "and force_default_config is on" do
         before do
           config_opts = {
-            :directory => @tmp_config.path,
             :force_default_config => true
           }
           @config = Brightbox::BBConfig.new(config_opts)
         end
 
-        it "raises an error" do
-          expect do
-            @config.client_name
-          end.to raise_error(Brightbox::BBConfigError, "You must specify a default client using brightbox config client_default")
+        it "returns nil" do
+          expect(@config.client_name).to be_nil
         end
       end
 
       context "and force_default_config is off" do
         before do
           config_opts = {
-            :directory => @tmp_config.path,
             :force_default_config => false
           }
           @config = Brightbox::BBConfig.new(config_opts)
         end
 
-        it "returns first client" do
+        it "returns nil" do
           expect(@config.client_name).to be_nil
         end
       end

--- a/spec/unit/brightbox/bb_config/config_directory_spec.rb
+++ b/spec/unit/brightbox/bb_config/config_directory_spec.rb
@@ -13,13 +13,15 @@ describe Brightbox::BBConfig do
     end
 
     context "when absolute custom location is set" do
+      let(:custom_dir) { Dir.mktmpdir("custom") }
+
       it "returns a String of the expanded directory" do
         config_options = {
-          :directory => "/etc/local/brightbox_cli"
+          :directory => custom_dir
         }
         config = Brightbox::BBConfig.new(config_options)
 
-        expect(config.config_directory).to eql("/etc/local/brightbox_cli")
+        expect(config.config_directory).to eql(custom_dir)
       end
     end
 

--- a/spec/unit/brightbox/bb_config/config_spec.rb
+++ b/spec/unit/brightbox/bb_config/config_spec.rb
@@ -10,7 +10,6 @@ describe Brightbox::BBConfig do
         Dir.mktmpdir do |tmp_dir|
           target_dir = File.join(tmp_dir, "config")
           @config = Brightbox::BBConfig.new :directory => target_dir
-          expect(@config.config_directory_exists?).to be false
           example.run
         end
       end
@@ -62,20 +61,17 @@ describe Brightbox::BBConfig do
     end
 
     context "when config file can not be parsed" do
-      around do |example|
+      it "raises an error" do
         Dir.mktmpdir do |target_dir|
           test_config_filename = File.join(target_dir, "config")
           File.open(test_config_filename, "w") do |f|
             f.puts "not:ini"
           end
 
-          @config = Brightbox::BBConfig.new :directory => target_dir
-          example.run
+          expect {
+            @config = Brightbox::BBConfig.new :directory => target_dir
+          }.to raise_error(Brightbox::BBConfigError)
         end
-      end
-
-      it "raises an error" do
-        expect { @config.config }.to raise_error(Brightbox::BBConfigError)
       end
     end
   end

--- a/spec/unit/brightbox/bb_config/default_account_spec.rb
+++ b/spec/unit/brightbox/bb_config/default_account_spec.rb
@@ -43,13 +43,17 @@ describe Brightbox::BBConfig do
     end
 
     context "when set in config" do
-      before do
-        @account_name = "acc-ghj32"
-        @client_name = "app-b3n5b"
-        contents = <<-EOS
-        [#{@client_name}]
-        default_account = #{@account_name}
+      let(:account_name) { "acc-ghj32" }
+      let(:client_name) { "app-b3n5b" }
+
+      let(:contents) do
+        <<-EOS
+        [#{client_name}]
+        default_account = #{account_name}
         EOS
+      end
+
+      before do
         @config = config_from_contents(contents)
       end
 

--- a/spec/unit/brightbox/bb_config/find_or_set_default_account_spec.rb
+++ b/spec/unit/brightbox/bb_config/find_or_set_default_account_spec.rb
@@ -61,6 +61,8 @@ describe Brightbox::BBConfig do
     context "when client may access one account", vcr: true do
       let(:contents) do
         <<-EOS
+        [core]
+        default_client = cli-12345
         [cli-12345]
         api_url = http://api.brightbox.dev
         client_id = cli-12345

--- a/spec/unit/brightbox/bb_config/renew_tokens_spec.rb
+++ b/spec/unit/brightbox/bb_config/renew_tokens_spec.rb
@@ -15,6 +15,9 @@ describe Brightbox::BBConfig do
     context "when using a user app with no tokens", vcr: true do
       before do
         contents = <<-EOS
+        [core]
+        default_client = app-12345
+
         [app-12345]
         api_url = #{api_endpoint}
         client_id = #{app_id}


### PR DESCRIPTION
Rather than needing to go and create a user application of their own,
this uses a public, general client for the CLI so only username/password
are required.

This can be done with the `login` command which takes an email (and
optional suffix after "/") and that sets up a minimal configuration.

This is reimplementation of #72 

This allows a suffix to be passed with the email address to create a
variant with alternative settings.

    brightbox login --default-account acc-54321 user@example.com/54321

The above would create a login for the same email address but using an
alternative account for the default. This allows passing it to other
commands using the existing form:

    brightbox -c user@example.com/54321 servers