### PR TITLE
Don't reset custom URLs when reusing `login`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.3.8)
     builder (3.2.2)
     coderay (1.0.9)
+    crack (0.4.2)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     excon (0.45.4)
     fog-brightbox (0.9.0)
@@ -62,8 +65,12 @@ GEM
     rspec-expectations (2.99.1)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.1)
+    safe_yaml (1.0.4)
     slop (3.4.5)
     vcr (2.5.0)
+    webmock (1.21.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
 
 PLATFORMS
   ruby
@@ -75,6 +82,7 @@ DEPENDENCIES
   rake
   rspec (~> 2.99)
   vcr (~> 2.5)
+  webmock
 
 BUNDLED WITH
    1.10.6

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 2.99"
   s.add_development_dependency "vcr", "~> 2.5"
+  s.add_development_dependency "webmock"
 
   s.post_install_message = <<-EOS
 The CLI command is now `brightbox` with subcommands for the resources.

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -31,17 +31,16 @@ module Brightbox
       end
       raise "You must specify your Brightbox password." if password.empty?
 
-      api_url = options[:"api-url"] || DEFAULT_API_ENDPOINT
-      auth_url = options[:"auth-url"] || api_url
-
       section_options = {
         :client_name => config_name,
         :alias => config_name,
         :username => email,
-        :password => password,
-        :api_url => api_url,
-        :auth_url => auth_url
+        :password => password
       }
+
+      section_options[:api_url] = options[:"api-url"] if options[:"api-url"]
+      section_options[:auth_url] = options[:"auth-url"] if options[:"auth-url"]
+
       section_options[:default_account] = options[:"default-account"] if options[:"default-account"]
 
       section_options[:client_id] = options[:"application-id"] if options[:"application-id"]

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -24,7 +24,7 @@ module Brightbox
         config_section["api_url"] = DEFAULT_API_ENDPOINT unless config_section["api_url"]
 
         config_section["auth_url"] = options[:auth_url] if options.key?(:auth_url)
-        config_section["auth_url"] = config_section["api_url"]
+        config_section["auth_url"] = config_section["api_url"] unless config_section["auth_url"]
 
         config_section["default_account"] = options[:default_account] if options.key?(:default_account)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ require "tmpdir"
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
+require "webmock/rspec"
+WebMock.disable_net_connect!
+
 # API_CLIENT_CONFIG_DIR = File.join(File.dirname(__FILE__), "configs/api_client")
 # USER_APP_CONFIG_DIR   = File.join(File.dirname(__FILE__), "configs/user_application")
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,7 +3,7 @@ require "vcr"
 VCR.configure do |vcr|
   vcr.cassette_library_dir = File.join(File.dirname(__FILE__), "../cassettes")
   vcr.allow_http_connections_when_no_cassette = false
-  vcr.hook_into :excon
+  vcr.hook_into :webmock
 
   vcr.configure_rspec_metadata!
   vcr.default_cassette_options = {
@@ -30,3 +30,13 @@ VCR.configure do |vcr|
     end
   end
 end
+
+VCR.turn_off!
+
+VCR.extend Module.new {
+  def use_cassette(*args)
+    VCR.turn_on!
+    super
+    VCR.turn_off!
+  end
+}


### PR DESCRIPTION
A bug in the conditions meant the default URLs were being being replaced
each time `login` was used.