### PR TITLE
Correctly set client name for `login`

### DIFF
--- a/lib/brightbox-cli/config.rb
+++ b/lib/brightbox-cli/config.rb
@@ -85,9 +85,9 @@ module Brightbox
     #
     def debug_tokens
       if ENV["DEBUG"]
-        debug "Access token: #{access_token}"
+        debug "Access token: #{access_token} (#{cached_access_token})"
         if using_application?
-          debug "Refresh token: #{refresh_token}"
+          debug "Refresh token: #{refresh_token} (#{cached_refresh_token}))"
         else
           debug "Refresh token: <NOT EXPECTED FOR CLIENT>"
         end

--- a/lib/brightbox-cli/config/authentication_tokens.rb
+++ b/lib/brightbox-cli/config/authentication_tokens.rb
@@ -224,15 +224,35 @@ module Brightbox
           f.write token
         end
         # Move process version into place
+        debug "Saving #{token} to #{filename}"
         FileUtils.mv filename + ".#{$PID}", filename
       end
 
       def cached_access_token
         File.open(access_token_filename, "r") { |fl| fl.read.chomp }
+      rescue Errno::ENOENT
+        nil
       end
 
       def cached_refresh_token
         File.open(refresh_token_filename, "r") { |fl| fl.read.chomp }
+      rescue Errno::ENOENT
+        nil
+      end
+
+      def remove_cached_tokens!
+        remove_access_token!
+        remove_refresh_token!
+      end
+
+      def remove_access_token!
+        @access_token = nil
+        FileUtils.rm(access_token_filename) if File.exist?(access_token_filename)
+      end
+
+      def remove_refresh_token!
+        @refresh_token = nil
+        FileUtils.rm(refresh_token_filename) if File.exist?(refresh_token_filename)
       end
 
       private

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -33,14 +33,16 @@ module Brightbox
 
         dirty!
 
-        self.client_name = client_alias
+        self.client_name = config_alias
+
+        debug "Using #{client_name}"
 
         # Renew tokens via config...
         #
         # Part of the "login" behaviour is to always refresh them
         #
         begin
-          flush_access_token!
+          remove_cached_tokens!
           renew_tokens(:client_name => config_alias, :password => password)
         rescue => e
           error "Something went wrong trying to refresh new tokens #{e.message}"


### PR DESCRIPTION
`#client_alias` method was used by mistake instead of `config_alias`
variable.

This meant the config was set to the default account whilst clearing the
access token.

The `#renew_tokens` call used the correct client since it is passed in
as an argument. However the presence of the refresh token was the reason
`#renew_tokens` would hit the branch without using the password.

This would forced a password prompt and a confusing message.