### PR TITLE
Fix blank zone in `brightbox servers show`

### DIFF
--- a/lib/brightbox-cli/detailed_server.rb
+++ b/lib/brightbox-cli/detailed_server.rb
@@ -3,7 +3,7 @@ module Brightbox
     def to_row
       row_attributes = attributes
 
-      row_attributes[:compatibility_mode] = attributes["compatibility_mode"]
+      row_attributes[:compatibility_mode] = row_attributes["compatibility_mode"]
 
       if server_type
         row_attributes[:type] = server_type['id']


### PR DESCRIPTION
Seems calling `attributes` a second time has a side effect which sets
`:zone` to be `nil`. We already have access to compatibility mode.