### PR TITLE
Update `fog-brightbox` to v0.10.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.3.4)
-      fog-brightbox (>= 0.9.0)
+      fog-brightbox (>= 0.10.1)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
@@ -21,17 +21,14 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     excon (0.45.4)
-    fog-brightbox (0.9.0)
+    fog-brightbox (0.10.1)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.32.1)
+    fog-core (1.35.0)
       builder
       excon (~> 0.45)
       formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
     fog-json (1.0.2)
       fog-core (~> 1.0)
       multi_json (~> 1.10)
@@ -43,12 +40,10 @@ GEM
     inflecto (0.0.2)
     metaclass (0.0.1)
     method_source (0.8.1)
-    mime-types (2.6.2)
+    mime-types (2.99)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
@@ -86,4 +81,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.9.0"
+  s.add_dependency "fog-brightbox", ">= 0.10.1"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "mime-types", "~> 2.6"


### PR DESCRIPTION
This primarily defaults the account nesting to be disabled resulting in
a faster version of `brightbox accounts list`