### PR TITLE
Add `sudo: false` to Travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Appears Travis CI updates to the environment shortly after the last set
of tests were run.

https://blog.travis-ci.com/2015-11-27-moving-to-a-more-elastic-future

The new environment is causing a number of errors and failures.

This is switching to their container based build env to see if that
changes things.