### PR TITLE
Don't nest account lookup when listing images

### DIFF
--- a/lib/brightbox-cli/images.rb
+++ b/lib/brightbox-cli/images.rb
@@ -40,8 +40,8 @@ module Brightbox
       end
 
       unless options[:a]
-        account = Account.conn.account
-        images.reject! { |i| !i.official && i.owner_id != account.id  }
+        account = Account.conn.get_scoped_account(:nested => false)
+        images.reject! { |i| !i.official && i.owner_id != account[:id]  }
       end
 
       snapshots = images.select { |i| i.source_type == 'snapshot' }


### PR DESCRIPTION
As per https://github.com/brightbox/honcho/pull/712 we can now get
accounts without nesting all their resources, which speeds up the
request a lot for large accounts.

We use the account id when listing images to fiter by owner but we only
need the account id, so don't need nesting.