### PR TITLE
Fix issue if `maintenance_weekday` not in JSON

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.5.0)
-      fog-brightbox (>= 0.10.1)
+      fog-brightbox (>= 0.11.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
@@ -20,12 +20,12 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    excon (0.49.0)
-    fog-brightbox (0.10.1)
+    excon (0.50.1)
+    fog-brightbox (0.11.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.39.0)
+    fog-core (1.42.0)
       builder
       excon (~> 0.49)
       formatador (~> 0.2)
@@ -40,7 +40,7 @@ GEM
     inflecto (0.0.2)
     metaclass (0.0.1)
     method_source (0.8.1)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.3)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.10.1"
+  s.add_dependency "fog-brightbox", ">= 0.11.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "mime-types", "~> 2.6"

--- a/lib/brightbox-cli/database_server.rb
+++ b/lib/brightbox-cli/database_server.rb
@@ -96,6 +96,7 @@ module Brightbox
 
     # A more humanised version of the maintenance window
     def maintenance_window
+      return nil if maintenance_weekday.nil?
       weekday = Date::DAYNAMES[maintenance_weekday]
       sprintf("%s %02d:00 UTC", weekday, maintenance_hour)
     end

--- a/spec/commands/sql/instances/show_spec.rb
+++ b/spec/commands/sql/instances/show_spec.rb
@@ -1,0 +1,72 @@
+require "spec_helper"
+
+describe "brghtbox sql instances" do
+  describe "show" do
+    let(:output) { FauxIO.new { Brightbox.run(argv) } }
+    let(:stdout) { output.stdout }
+    let(:stderr) { output.stderr }
+
+    before do
+      config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+      cache_access_token(config, "1234567890")
+    end
+
+    context "when id does not exist" do
+      let(:argv) { %w(sql instances show dbs-12345) }
+      let(:json_response) do
+        "{\"error_name\":\"missing_resource\",\"errors\":[\"Resource not found using supplied identifier\"]}"
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345").
+          to_return(:status => 404, :body => json_response, :headers => { "Content-Type" => "" })
+      end
+
+      it "reports error" do
+        expect(stderr).to include("ERROR: Couldn't find an SQL instance with ID dbs-12345")
+        expect(stdout).to be_empty
+      end
+    end
+
+    context "when id exists" do
+      let(:argv) { %w(sql instances show dbs-12345) }
+
+      let(:json_response) do
+        <<-EOS
+        {
+          "id":"dbs-12345",
+          "resource_type":"database_server",
+          "url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-12345",
+          "name":"",
+          "description":"",
+          "admin_username":"admin",
+          "admin_password":null,
+          "allow_access":[],
+          "database_engine":"mysql",
+          "database_version":"5.5",
+          "status":"active",
+          "maintenance_weekday":0,
+          "maintenance_hour":6,
+          "created_at":"2016-07-07T12:34:56Z",
+          "updated_at":"2016-07-07T12:34:56Z",
+          "deleted_at":null,
+          "account":{},
+          "database_server_type":{},
+          "cloud_ips":[],
+          "zone":{}
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345").
+          to_return(:status => 200, :body => json_response, :headers => { "Content-Type" => "" })
+      end
+
+      it "simplifies the maintenance window" do
+        expect(stdout).to include("maintenance_window: Sunday 06:00 UTC")
+        expect(stderr).to be_empty
+      end
+    end
+  end
+end

--- a/spec/unit/brightbox/database_server/maintenance_window_spec.rb
+++ b/spec/unit/brightbox/database_server/maintenance_window_spec.rb
@@ -32,5 +32,13 @@ describe Brightbox::DatabaseServer do
         expect(dbs.maintenance_window).to eql("Saturday 23:00 UTC")
       end
     end
+
+    context "when not initialised" do
+      let(:fog_settings) { {} }
+
+      it "returns nil" do
+        expect(dbs.maintenance_window).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Whilst highly unlikely, this fixes a raised TypeError if the response
from the API does not have the `maintenance_weekday` field in the
response.

The most likely case of this is in specs where only a subset of the
response is needed for other testing concerns. This bug would require
those to have this field, just to avoid this bug.