### PR TITLE
Guard more JSON fields

### DIFF
--- a/lib/brightbox-cli/api.rb
+++ b/lib/brightbox-cli/api.rb
@@ -186,7 +186,9 @@ module Brightbox
     # Displays creation date in ISO 8601 Complete date format
     #
     def created_on
-      fog_model.created_at.strftime("%Y-%m-%d")
+      if fog_model.created_at
+        fog_model.created_at.strftime("%Y-%m-%d")
+      end
     end
   end
 end

--- a/lib/brightbox-cli/database_server.rb
+++ b/lib/brightbox-cli/database_server.rb
@@ -101,6 +101,10 @@ module Brightbox
       sprintf("%s %02d:00 UTC", weekday, maintenance_hour)
     end
 
+    def cloud_ips
+      super.nil? ? [] : super
+    end
+
     # Lists the CIP identifiers (cip-12345)
     def cloud_ip_ids
       cloud_ips.map { |cip| cip["id"] }

--- a/spec/unit/brightbox/api/created_on_spec.rb
+++ b/spec/unit/brightbox/api/created_on_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+describe Brightbox::Api, "#created_on" do
+  subject(:api_model) { described_class.new(fog_model) }
+  let(:fog_model) do
+    double id: nil,
+          attributes: attrs,
+          created_at: attrs[:created_at]
+  end
+
+  context "when initialised with no attributes" do
+    let(:attrs) { {} }
+
+    it { expect(api_model.created_on).to be_nil }
+  end
+
+  context "when initialised with created_at" do
+    let(:attrs) { { created_at: Time.utc(2016, 7, 7, 12, 34, 56) } }
+
+    it { expect(api_model.created_on).to eq("2016-07-07") }
+  end
+end

--- a/spec/unit/brightbox/database_server/cloud_ips_spec.rb
+++ b/spec/unit/brightbox/database_server/cloud_ips_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/database_server"
+
+describe Brightbox::DatabaseServer, "#cloud_ips" do
+  let(:fog_model) { Fog::Compute::Brightbox::DatabaseServer.new(fog_settings) }
+  let(:dbs) { described_class.new(fog_model) }
+
+  context "when attribute is missing" do
+    let(:fog_settings) { {} }
+    it { expect(dbs.cloud_ips).to be_empty }
+  end
+
+  context "when attribute is empty" do
+    let(:fog_settings) { { cloud_ips: [] } }
+    it { expect(dbs.cloud_ips).to be_empty }
+  end
+
+  context "when attribute contains data" do
+    let(:cloud_ip) { { id: "cip-12345", public_ip: "10.0.0.10" } }
+    let(:fog_settings) { { cloud_ips: [cloud_ip] } }
+    it { expect(dbs.cloud_ips).to include(cloud_ip) }
+  end
+end


### PR DESCRIPTION
Changes to prevent errors when accessing fields where
the JSON/attributes have not been initialised.

Normally the API responses always include theses fields but
under tests, we can save boilerplate responses by making the
code more robust.