### PR TITLE
Add support for `snapshots-schedule` argument

### DIFF
--- a/lib/brightbox-cli/commands/sql/instances_create.rb
+++ b/lib/brightbox-cli/commands/sql/instances_create.rb
@@ -33,6 +33,10 @@ module Brightbox
         c.desc I18n.t("sql.instances.options.maintenance_hour.desc")
         c.flag ["maintenance-hour"]
 
+        # Snapshots schedule
+        c.desc I18n.t("sql.instances.options.snapshots_schedule.desc")
+        c.flag [:"snapshots-schedule"]
+
         # Snapshot
         c.desc I18n.t("sql.instances.options.snapshot.desc")
         c.flag [:snapshot]

--- a/lib/brightbox-cli/commands/sql/instances_update.rb
+++ b/lib/brightbox-cli/commands/sql/instances_update.rb
@@ -21,6 +21,12 @@ module Brightbox
         c.desc I18n.t("sql.instances.options.maintenance_hour.desc")
         c.flag ["maintenance-hour"]
 
+        # Snapshots schedule
+        c.desc I18n.t("sql.instances.options.snapshots_schedule.desc")
+        c.flag [:"snapshots-schedule"]
+        c.desc I18n.t("sql.instances.options.remove_snapshots_schedule.desc")
+        c.switch [:"remove-snapshots-schedule"], :negatable => false
+
         c.action do |global_options, options, args|
           dbs_id = args.shift
           unless dbs_id =~ /^dbs-/

--- a/lib/brightbox-cli/database_server.rb
+++ b/lib/brightbox-cli/database_server.rb
@@ -54,6 +54,8 @@ module Brightbox
         :created_on,
         :admin_username, :admin_password,
         :maintenance_window,
+        :snapshots_schedule,
+        :snapshots_schedule_next_at,
         :allow_access,
         :cloud_ip_ids, :cloud_ips
       ]
@@ -130,6 +132,11 @@ module Brightbox
         params[:maintenance_weekday] = weekday_index(args["maintenance-weekday"])
       end
       params[:maintenance_hour] = args["maintenance-hour"] if args["maintenance-hour"]
+
+      params[:snapshots_schedule] = args["snapshots-schedule"] if args["snapshots-schedule"]
+      if args["remove-snapshots-schedule"]
+        params[:snapshots_schedule] = nil
+      end
 
       params[:database_engine] = args[:engine] if args[:engine]
       params[:database_version] = args["engine-version"] if args["engine-version"]

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -185,6 +185,10 @@ en:
                 maintenance window (0-6 where 0=Sunday)
         snapshot:
           desc: ID of a Cloud SQL snapshot to create new instance from
+        snapshots_schedule:
+          desc: Create or reschedule automatic snapshots using crontab format (e.g. "0 5 * * *"). May not be more than hourly.
+        remove_snapshots_schedule:
+          desc: Clear an existing snapshots schedule
         type:
           desc: ID of a Cloud SQL type
         zone:

--- a/spec/commands/sql/instances/create_spec.rb
+++ b/spec/commands/sql/instances/create_spec.rb
@@ -103,5 +103,32 @@ describe "brightbox sql instances" do
         expect(stderr).to eql("")
       end
     end
+
+    context "--snapshots-schedule='0 12 * * 4'" do
+      let(:argv) { ["sql", "instances", "create", "--snapshots-schedule=0 12 * * 4"] }
+      let(:expected_args) { { :snapshots_schedule => "0 12 * * 4" } }
+
+      let(:json_response) do
+        <<-EOS
+        {
+          "id":"dbs-12345",
+          "snapshots_schedule":"0 12 * * 4",
+          "snapshots_schedule_next_at":"2016-07-07T12:00:00Z"
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:post, "http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345")
+          .and_return(:status => 202, :body => json_response)
+      end
+
+      it "includes schedule fields in response" do
+        expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
+        expect(stdout).to include("snapshots_schedule: 0 12 * * 4")
+        expect(stdout).to include("snapshots_schedule_next_at: 2016-07-07T12:00Z")
+        expect(stderr).to eql("")
+      end
+    end
   end
 end

--- a/spec/commands/sql/instances/show_spec.rb
+++ b/spec/commands/sql/instances/show_spec.rb
@@ -47,6 +47,8 @@ describe "brghtbox sql instances" do
           "status":"active",
           "maintenance_weekday":0,
           "maintenance_hour":6,
+          "snapshots_schedule":"0 16 * * 0",
+          "snapshots_schedule_next_at":"2016-07-10T16:00:00Z",
           "created_at":"2016-07-07T12:34:56Z",
           "updated_at":"2016-07-07T12:34:56Z",
           "deleted_at":null,
@@ -66,6 +68,11 @@ describe "brghtbox sql instances" do
       it "simplifies the maintenance window" do
         expect(stdout).to include("maintenance_window: Sunday 06:00 UTC")
         expect(stderr).to be_empty
+      end
+
+      it "includes snapshots schedule fields" do
+        expect(stdout).to include("snapshots_schedule: 0 16 * * 0")
+        expect(stdout).to include("snapshots_schedule_next_at: 2016-07-10T16:00Z")
       end
     end
   end


### PR DESCRIPTION
SQL instances can be configured to automatically perform a snapshot
based on a crontab schedule.

Fields are in the following order:

  * Minutes (0-60) **Note** there is a limit of once per hour so the
    minutes field may not be "*" or a range of values.
  * Hours (0-23)
  * Day of month (1-31)
  * Month (1-12)
  * Day of week (0-6) **Note** Sunday is 0

See https://en.wikipedia.org/wiki/Cron#Format

So the argument `--snapshots-schedule="0 5 * * 0"` will prepare a
schedule to run every Sunday at 05:00.

A schedule may be cleared with `--remove-snapshots-schedule`