### PR TITLE
Add --cloud-ip argument to new server requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.6.0)
-      fog-brightbox (>= 0.11.0)
+      fog-brightbox (>= 0.13.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
@@ -15,19 +15,19 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    builder (3.2.2)
+    builder (3.2.3)
     coderay (1.0.9)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    excon (0.50.1)
-    fog-brightbox (0.11.0)
+    excon (0.58.0)
+    fog-brightbox (0.13.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.42.0)
+    fog-core (1.45.0)
       builder
-      excon (~> 0.49)
+      excon (~> 0.58)
       formatador (~> 0.2)
     fog-json (1.0.2)
       fog-core (~> 1.0)
@@ -40,7 +40,7 @@ GEM
     inflecto (0.0.2)
     metaclass (0.0.1)
     method_source (0.8.1)
-    mime-types (2.99.2)
+    mime-types (2.99.3)
     mocha (0.14.0)
       metaclass (~> 0.0.1)
     multi_json (1.11.3)
@@ -81,4 +81,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.11.0"
+  s.add_dependency "fog-brightbox", ">= 0.13.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "mime-types", "~> 2.6"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -142,6 +142,8 @@ en:
       desc: Activate web consoles for a number of servers
     create:
       desc: Create servers
+      cloud_ip:
+        desc: Immediately map a Cloud IP to new server? Either "true" or the identifier of the Cloud IP
     destroy:
       desc: Destroy servers
     lock:

--- a/spec/commands/servers/create_spec.rb
+++ b/spec/commands/servers/create_spec.rb
@@ -7,12 +7,85 @@ describe "brightbox servers" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+      cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
+
+      stub_request(:post, "http://api.brightbox.dev/token").to_return(
+        :status => 200,
+        :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}')
+    end
+
+    context "without arguments" do
       let(:argv) { %w(servers create) }
 
       it "does not error" do
         expect { output }.to_not raise_error
       end
+    end
+
+    context "with --cloud-ip with nominated IP argument" do
+      let(:argv) { %w(servers create --cloud-ip cip-12345 img-12345) }
+
+      let(:image) { double(:id => "img-12345", :name => "Linux") }
+      let(:type) { double(:id => "typ-12345", :handle => "nano") }
+      let(:zone) { double(:handle => "gb1-a") }
+
+      before do
+        expect(Brightbox::Image).to receive(:find).with("img-12345").and_return(image)
+        expect(Brightbox::Type).to receive(:find_by_handle).and_return(type)
+      end
+
+      it "requests nominated Cloud IP" do
+        stub_request(:post, "http://api.brightbox.dev/1.0/servers?account_id=acc-12345")
+          .with(:body => /"cloud_ip":"cip-12345"/)
+          .and_return(:status => 202, :body => sample_response)
+
+        expect(stderr).to match("mapping cip-12345 when built")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("srv-12345")
+      end
+    end
+
+    context "with --cloud-ip true argument" do
+      let(:argv) { %w(servers create --cloud-ip true img-12345) }
+
+      let(:image) { double(:id => "img-12345", :name => "Linux") }
+      let(:type) { double(:id => "typ-12345", :handle => "nano") }
+      let(:zone) { double(:handle => "gb1-a") }
+
+      before do
+        expect(Brightbox::Image).to receive(:find).with("img-12345").and_return(image)
+        expect(Brightbox::Type).to receive(:find_by_handle).and_return(type)
+      end
+
+      it "requests new allocated Cloud IP" do
+        stub_request(:post, "http://api.brightbox.dev/1.0/servers?account_id=acc-12345")
+          .with(:body => /"cloud_ip":"true"/)
+          .and_return(:status => 202, :body => sample_response)
+
+        expect(stderr).to match("mapping a new cloud IP when built")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("srv-12345")
+      end
+    end
+
+    def sample_response
+      '{
+        "id": "srv-12345",
+        "image": {
+          "id": "img-12345"
+        },
+        "interfaces": [],
+        "server_type": {
+          "handle": "nano"
+        },
+        "zone": {
+          "handle": "gb1-a"
+        },
+        "cloud_ips": [],
+        "snapshots": []
+      }'
     end
   end
 end


### PR DESCRIPTION
This allows the creation of servers that immediately map a Cloud IP upon
being built.

The argument can accept either "true" which requests the allocation of a
new Cloud IP for the built.

Alternatively it can accept an identifier (`cli-12345`) for an unmapped
Cloud IP and that nominated IP will be reserved and mapped instead.