### PR TITLE
Update bundler for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 sudo: false
+before_install:
+  - gem install bundler
 rvm:
   - 1.9
   - 2.0


### PR DESCRIPTION
Ruby 1.9.3 seems to be having problems on Travis. Unfortunately, it
looks like changing the default bundler may resolve it.