### PR TITLE
Update and limit `fog-brightbox` dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.8.1)
-      fog-brightbox (>= 0.14.0)
+      fog-brightbox (>= 0.14.0, < 1.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
@@ -20,16 +20,17 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     excon (0.62.0)
-    fog-brightbox (0.14.0)
+    fog-brightbox (0.15.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
+      mime-types
     fog-core (1.45.0)
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-    fog-json (1.0.2)
-      fog-core (~> 1.0)
+    fog-json (1.2.0)
+      fog-core
       multi_json (~> 1.10)
     formatador (0.2.5)
     gli (2.12.3)
@@ -79,4 +80,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.0
+   1.16.2

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.14.0"
+  s.add_dependency "fog-brightbox", ">= 0.14.0", "< 1.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "mime-types", "~> 2.6"


### PR DESCRIPTION
The next release of `fog-brightbox` is planned to be a major release and
drops support for Ruby 1.9 and 2.0.

It also fixes a long standing namespacing issue that is incompatible
with the tests in this codebase.

So this updates `fog-brightbox` to fix a few issues and adds a
constraint so it will not pick up a v1.0 gem if updating itself.