### PR TITLE
Fix image filtering

### DIFF
--- a/lib/brightbox-cli/images.rb
+++ b/lib/brightbox-cli/images.rb
@@ -41,7 +41,7 @@ module Brightbox
 
       unless options[:a]
         account = Account.conn.get_scoped_account(:nested => false)
-        images.reject! { |i| !i.official && i.owner_id != account[:id]  }
+        images.reject! { |i| !i.official && i.owner_id != account["id"]  }
       end
 
       snapshots = images.select { |i| i.source_type == 'snapshot' }

--- a/spec/commands/images/list_spec.rb
+++ b/spec/commands/images/list_spec.rb
@@ -7,11 +7,150 @@ describe "brightbox images" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      config_from_contents(USER_APP_CONFIG_CONTENTS)
+
+      stub_request(:post, "http://api.brightbox.dev/token").
+        to_return(status: 200, body: JSON.dump(access_token: "ACCESS-TOKEN", refresh_token: "REFRESH-TOKEN"))
+
+      image_listing_json = JSON.dump([
+        {
+          id: "img-test1",
+          name: "Official image",
+          status: "available",
+          official: true,
+          public: true,
+          source_type: "upload",
+          owner: "acc-99999"
+        },
+        {
+          id: "img-test2",
+          name: "Public image",
+          status: "available",
+          official: false,
+          public: true,
+          source_type: "upload",
+          owner: "acc-abcde"
+        },
+        {
+          id: "img-test3",
+          name: "Customer image",
+          status: "available",
+          official: false,
+          public: false,
+          source_type: "upload",
+          owner: "acc-12345"
+        },
+        {
+          id: "img-test4",
+          name: "Customer snapshot",
+          status: "available",
+          official: false,
+          public: false,
+          source_type: "snapshot",
+          owner: "acc-12345"
+        },
+        {
+          id: "img-test5",
+          name: "Customer deleting image",
+          status: "deleting",
+          official: false,
+          public: false,
+          source_type: "upload",
+          owner: "acc-12345"
+        }
+      ])
+
+      stub_request(:get, "http://api.brightbox.dev/1.0/images?account_id=acc-12345").
+        with(headers: { "Authorization" => "Bearer ACCESS-TOKEN" }).
+        to_return(status: 200, body: image_listing_json)
+
+      stub_request(:get, "http://api.brightbox.dev/1.0/account?account_id=acc-12345&nested=false").
+        with(headers: { "Authorization" => "Bearer ACCESS-TOKEN" }).
+        to_return(status: 200, body: JSON.dump({ id: "acc-12345" }))
+    end
+
+    context "when default listing" do
       let(:argv) { %w(images list) }
 
       it "does not error" do
-        expect { output }.to_not raise_error
+        expect(stderr).not_to include("ERROR")
+
+        expect(stdout).to include("img-test1")
+        expect(stdout).not_to include("img-test2")
+        expect(stdout).to include("img-test3")
+        expect(stdout).to include("img-test4")
+        expect(stdout).to include("img-test5")
+      end
+    end
+
+    context "when listing all cases" do
+      let(:argv) { %w(images list --show-all) }
+
+      it "does not error" do
+        expect(stderr).not_to include("ERROR")
+
+        expect(stdout).to include("img-test1")
+        expect(stdout).to include("img-test2")
+        expect(stdout).to include("img-test3")
+        expect(stdout).to include("img-test4")
+        expect(stdout).to include("img-test5")
+      end
+    end
+
+    context "when filtering by status" do
+      let(:argv) { %w(images list --status deleting) }
+
+      it "does not error" do
+        expect(stderr).not_to include("ERROR")
+
+        expect(stdout).not_to include("img-test1")
+        expect(stdout).not_to include("img-test2")
+        expect(stdout).not_to include("img-test3")
+        expect(stdout).not_to include("img-test4")
+        expect(stdout).to include("img-test5")
+      end
+    end
+
+    context "when filtering by type" do
+      let(:argv) { %w(images list --type snapshot) }
+
+      it "does not error" do
+        expect(stderr).not_to include("ERROR")
+
+        expect(stdout).not_to include("img-test1")
+        expect(stdout).not_to include("img-test2")
+        expect(stdout).not_to include("img-test3")
+        expect(stdout).to include("img-test4")
+        expect(stdout).not_to include("img-test5")
+      end
+    end
+
+    context "when filtering by own account ID" do
+      let(:argv) { %w(images list --account acc-12345) }
+
+      it "does not error" do
+        expect(stderr).not_to include("ERROR")
+
+        expect(stdout).not_to include("img-test1")
+        expect(stdout).not_to include("img-test2")
+        expect(stdout).to include("img-test3")
+        expect(stdout).to include("img-test4")
+        expect(stdout).to include("img-test5")
+      end
+    end
+
+    context "when filter by own account ID and all" do
+      let(:argv) { %w(images list --account acc-12345 --show-all) }
+
+      it "does not error" do
+        expect(stderr).not_to include("ERROR")
+
+        expect(stdout).not_to include("img-test1")
+        expect(stdout).not_to include("img-test2")
+        expect(stdout).to include("img-test3")
+        expect(stdout).to include("img-test4")
+        expect(stdout).to include("img-test5")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift LIB_DIR unless
   $LOAD_PATH.include?(LIB_DIR) || $LOAD_PATH.include?(File.expand_path(LIB_DIR))
 
 require "brightbox_cli"
+require "json"
 require "tmpdir"
 
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }


### PR DESCRIPTION
When https://github.com/brightbox/brightbox-cli/pull/83 was merged, the
`account` was changed from a fog model (responding to `#id`) to a hash
with `#[]` key access.

At some point, the key type has changed - potentially caused by a Ruby
or `fog` change - from a symbol to a string.

The key change meant that the image listings had a filter that was used
by default but would filter anything without an owner ID of `nil`. That
meant everything.

The workaround was using `--show-all` which disabled this filter but
then included other images that were not interesting.

This fixes the key type to `String` for now which seems to work with
several versions of Ruby and the latest fog gems.

For: #97 