### PR TITLE
Add `brightbox token` command

### DIFF
--- a/lib/brightbox-cli/commands/token.rb
+++ b/lib/brightbox-cli/commands/token.rb
@@ -1,0 +1,19 @@
+module Brightbox
+  desc "Authentication token management"
+  command [:token] do |cmd|
+    cmd.default_command :show
+
+    cmd.desc "Show currently cached OAuth2 Bearer token"
+    cmd.command [:show] do |c|
+      c.desc "Either 'text', 'token', 'json' or 'curl'"
+      c.arg_name "format"
+      c.default_value "text"
+      c.flag [:format]
+
+      c.action do |global_options, options, args|
+        token = Token.show(Brightbox.config, options)
+        $stdout.puts token.format(options[:format])
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/token.rb
+++ b/lib/brightbox-cli/token.rb
@@ -1,0 +1,73 @@
+require "json"
+
+module Brightbox
+  class Token
+    def self.show(config, options)
+      new(config, options)
+    end
+
+    attr_accessor :config, :options
+
+    def initialize(config, options = {})
+      @config = config
+      @options = options
+    end
+
+    def access_token
+      config.access_token
+    end
+
+    def format(output = :text)
+      output = output.to_sym
+
+      case output
+      when :curl
+        curl_output
+      when :json
+        json_output
+      when :token
+        token_output
+      else
+        text_output
+      end
+    end
+
+    def refresh_token
+      config.refresh_token
+    end
+
+    private
+
+    def api_url
+      base_url = URI(config.to_fog[:brightbox_api_url]).to_s
+      URI.join(base_url, "/1.0/").to_s
+    end
+
+    def curl_output
+      "curl - H 'Authorization: Bearer #{access_token}' #{api_url} "
+    end
+
+    def json_output
+      JSON.dump(token_data)
+    end
+
+    def text_output
+      token_data.map do |key, value|
+        "#{key.to_s.rjust(16)}: #{value}"
+      end.join("\n")
+    end
+
+    def token_data
+      data = {
+        access_token: access_token,
+        token_type: "Bearer"
+      }
+      data[:refresh_token] = refresh_token if refresh_token
+      data.sort.to_h
+    end
+
+    def token_output
+      access_token
+    end
+  end
+end

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -56,6 +56,7 @@ module Brightbox
   autoload :DatabaseType, File.expand_path("../brightbox-cli/database_type", __FILE__)
   autoload :DatabaseServer, File.expand_path("../brightbox-cli/database_server", __FILE__)
   autoload :DatabaseSnapshot, File.expand_path("../brightbox-cli/database_snapshot", __FILE__)
+  autoload :Token, File.expand_path("../brightbox-cli/token", __FILE__)
 
   module Config
     autoload :SectionNameDeduplicator, File.expand_path("../brightbox-cli/config/section_name_deduplicator", __FILE__)


### PR DESCRIPTION
This adds a new command to display the currently available OAuth2 bearer
token cached by the tool.

    $ brightbox token show
    INFO: client_id: sample (sample)
        access_token: 4f58a9eb8e91dbc9aba1fc8cc5dd21478f2ba03b
       refresh_token: 34266b2428ca2d28d58ce0359c861fe2d0eef2e7
          token_type: Bearer

It supports multiple output formats:

* 'text'  - Verbose table of tokens and values
* 'token' - Just the access token
* 'json'  - JSON version of 'text' for machine parsing.
* 'curl'  - Sample output for curl including header token and API URL.