### PR TITLE
Fix errant space in `token` curl output

### DIFF
--- a/lib/brightbox-cli/token.rb
+++ b/lib/brightbox-cli/token.rb
@@ -44,7 +44,7 @@ module Brightbox
     end
 
     def curl_output
-      "curl - H 'Authorization: Bearer #{access_token}' #{api_url} "
+      "curl -H 'Authorization: Bearer #{access_token}' #{api_url} "
     end
 
     def json_output


### PR DESCRIPTION
A typo left the curl formatted output invalid due to an extra space.