### PR TITLE
Update `fog-brightbox` to v0.16.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.9.1)
-      fog-brightbox (>= 0.14.0, < 1.0)
-      fog-core (< 2.1.1)
+      fog-brightbox (>= 0.16.0, < 1.0)
+      fog-core (< 2.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
@@ -22,16 +22,15 @@ GEM
     diff-lcs (1.2.5)
     dry-inflector (0.1.2)
     excon (0.62.0)
-    fog-brightbox (0.16.0)
+    fog-brightbox (0.16.1)
       dry-inflector
       fog-core
       fog-json
       mime-types
-    fog-core (2.1.0)
+    fog-core (1.45.0)
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
-      mime-types
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.14.0", "< 1.0"
-  s.add_dependency "fog-core", "< 2.1.1"
+  s.add_dependency "fog-brightbox", ">= 0.16.0", "< 1.0"
+  s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "mime-types", "~> 2.6"


### PR DESCRIPTION
And issue in `fog-core` exposed an ordering bug where services were
being declared before autoloading was. The core change meant a large
deprecation warning and also an error.

Updating to `fog-brightbox v0.16.1` fixes the warning but it is safest
to limit fog-core to < 2.0 when deprecation behaviours were being added.

Due to upstream requirements, the dependency can not be declared in
fog-brightbox itself.

This also returns support for Ruby 1.9 which fog (core) drops in 2.0