### PR TITLE
Do not manually install bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 sudo: false
-before_install:
-  - gem install bundler
 rvm:
   - 1.9
   - 2.0


### PR DESCRIPTION
Travis is supposed to be install a valid version of bundler for us now
and a version < 2 for Ruby versions older than 2.3