### PR TITLE
Fix `dry-inflector` to retain older Ruby support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (2.11.0)
+      dry-inflector (< 0.2)
       fog-brightbox (>= 0.16.0, < 1.0)
       fog-core (< 2.0)
       gli (~> 2.12.0)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |s|
   s.add_dependency "highline", "~> 1.6.0"
   s.add_dependency "hirb", "~> 0.6"
 
+  # dry-inflector >= 0.2 drops supports for Ruby < 2.4
+  s.add_dependency "dry-inflector", "< 0.2"
+
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-remote"
   s.add_development_dependency "rake"


### PR DESCRIPTION
`dry-inflector v2.0` dropped support for Rubies older than 2.4 and
enforced it in their gemspec. This causes issues on LTS versions of
Linux with older Ruby versions when installing the gem.

This limits it to older versions that are still supported so gem
installation should continue to work.