### PR TITLE
Update `fog-brightbox` to v1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 sudo: false
 
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (2.12.0)
       dry-inflector (< 0.2)
-      fog-brightbox (>= 0.16.0, < 1.0)
+      fog-brightbox (>= 1.1.0)
       fog-core (< 2.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
@@ -22,12 +22,11 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     dry-inflector (0.1.2)
-    excon (0.72.0)
-    fog-brightbox (0.16.1)
+    excon (0.75.0)
+    fog-brightbox (1.1.0)
       dry-inflector
-      fog-core
+      fog-core (>= 1.45, < 3.0)
       fog-json
-      mime-types
     fog-core (1.45.0)
       builder
       excon (~> 0.58)
@@ -82,4 +81,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,17 +9,6 @@ pipeline {
   stages {
     stage("Run tests") {
       parallel {
-        stage("Ruby 1.9.3") {
-          agent {
-            docker {
-              image 'ruby:1.9.3'
-            }
-          }
-          steps {
-            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config BUNDLE_DISABLE_SHARED_GEMS=true bundle install --deployment'
-            sh 'BUNDLE_APP_CONFIG=/tmp/bundle.config bundle exec rake test'
-          }
-        }
         stage("Ruby 2.0") {
           agent {
             docker {

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 0.16.0", "< 1.0"
+  s.add_dependency "fog-brightbox", ">= 1.1.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = %q(Scripts to interact with the Brightbox cloud API)
   s.license     = "MIT"
 
-  s.required_ruby_version = ">= 1.9.3"
+  s.required_ruby_version = ">= 2.0"
 
   s.rubyforge_project = "brightbox-cli"
 

--- a/lib/brightbox-cli/api.rb
+++ b/lib/brightbox-cli/api.rb
@@ -16,7 +16,7 @@ module Brightbox
     # Returns the current connection to the Brightbox API, creating a new
     # {ConnectionManager} and connection if necessary.
     #
-    # @return [Fog::Compute::Brightbox::Real]
+    # @return [Fog::Brightbox::Compute::Real]
     #
     def self.conn
       if @@connection_manager

--- a/lib/brightbox-cli/collaboration.rb
+++ b/lib/brightbox-cli/collaboration.rb
@@ -9,7 +9,7 @@ module Brightbox
     def self.invite(email, role)
       options = { :email => email, :role => role }
       data = conn.create_collaboration(options)
-      model = Fog::Compute::Brightbox::Collaboration.new(data)
+      model = Fog::Brightbox::Compute::Collaboration.new(data)
       new(model)
     end
 

--- a/lib/brightbox-cli/commands/firewall/policies-update.rb
+++ b/lib/brightbox-cli/commands/firewall/policies-update.rb
@@ -36,7 +36,7 @@ module Brightbox
         # with a request, before updating the model
         data = FirewallPolicy.conn.update_firewall_policy(policy_id, params)
 
-        model = Fog::Compute::Brightbox::FirewallPolicy.new(data)
+        model = Fog::Brightbox::Compute::FirewallPolicy.new(data)
         policy = FirewallPolicy.new(model)
 
         render_table([policy], global_options)

--- a/spec/support/shared/collaborating_accounts_context.rb
+++ b/spec/support/shared/collaborating_accounts_context.rb
@@ -19,7 +19,7 @@ shared_context "collaborating accounts" do
       "load_balancers_limit" => 5,
       "load_balancers_used" => 0
     }
-    Fog::Compute::Brightbox::Account.new(data)
+    Fog::Brightbox::Compute::Account.new(data)
   end
 
   # As returned from conn.user_collaborations.all
@@ -35,7 +35,7 @@ shared_context "collaborating accounts" do
         "status" => "active"
       }
     }
-    Fog::Compute::Brightbox::UserCollaboration.new(data)
+    Fog::Brightbox::Compute::UserCollaboration.new(data)
   end
 
   # As returned from conn.user_collaborations.all
@@ -51,6 +51,6 @@ shared_context "collaborating accounts" do
         "status" => "active"
       }
     }
-    Fog::Compute::Brightbox::UserCollaboration.new(data)
+    Fog::Brightbox::Compute::UserCollaboration.new(data)
   end
 end

--- a/spec/unit/brightbox/account/all_spec.rb
+++ b/spec/unit/brightbox/account/all_spec.rb
@@ -13,7 +13,7 @@ describe Brightbox::Account do
         expect(Brightbox::Account.all).to be_kind_of(Array)
 
         Brightbox::Account.all.each do |account|
-          expect(account).to be_kind_of(Fog::Compute::Brightbox::Account)
+          expect(account).to be_kind_of(Fog::Brightbox::Compute::Account)
         end
       end
 
@@ -31,7 +31,7 @@ describe Brightbox::Account do
         expect(Brightbox::Account.all).to be_kind_of(Array)
 
         Brightbox::Account.all.each do |account|
-          expect(account).to be_kind_of(Fog::Compute::Brightbox::Account)
+          expect(account).to be_kind_of(Fog::Brightbox::Compute::Account)
         end
       end
 

--- a/spec/unit/brightbox/account/get_spec.rb
+++ b/spec/unit/brightbox/account/get_spec.rb
@@ -18,7 +18,7 @@ describe Brightbox::Account do
         end
 
         it "returns requested account" do
-          expect(@account).to be_kind_of(Fog::Compute::Brightbox::Account)
+          expect(@account).to be_kind_of(Fog::Brightbox::Compute::Account)
           expect(@account.id).to eql(@account_id)
         end
 
@@ -46,7 +46,7 @@ describe Brightbox::Account do
         end
 
         it "returns the client's owning account" do
-          expect(@account).to be_kind_of(Fog::Compute::Brightbox::Account)
+          expect(@account).to be_kind_of(Fog::Brightbox::Compute::Account)
           expect(@account.id).to eql(@account_id)
         end
 

--- a/spec/unit/brightbox/api/conn_spec.rb
+++ b/spec/unit/brightbox/api/conn_spec.rb
@@ -7,7 +7,7 @@ describe Brightbox::Api, ".conn" do
 
   context "when account is not required", vcr: true do
     it "returns a 'real' fog compute instance" do
-      expect(Brightbox::Api.conn).to be_instance_of(Fog::Compute::Brightbox::Real)
+      expect(Brightbox::Api.conn).to be_instance_of(Fog::Brightbox::Compute::Real)
     end
   end
 end

--- a/spec/unit/brightbox/collaborating_account_spec.rb
+++ b/spec/unit/brightbox/collaborating_account_spec.rb
@@ -5,7 +5,7 @@ describe Brightbox::CollaboratingAccount do
     data = {
       "id" => "acc-12345"
     }
-    account_model = Fog::Compute::Brightbox::Account.new(data)
+    account_model = Fog::Brightbox::Compute::Account.new(data)
     Brightbox::CollaboratingAccount.new(account_model)
   end
 

--- a/spec/unit/brightbox/connection_manager/fetch_connection_spec.rb
+++ b/spec/unit/brightbox/connection_manager/fetch_connection_spec.rb
@@ -19,7 +19,7 @@ describe Brightbox::ConnectionManager, "#fetch_connection" do
 
   context "when not requesting a scoped connection" do
     it "returns a fog compute instance" do
-      expect(connection_manager.fetch_connection(false)).to be_kind_of(Fog::Compute::Brightbox::Real)
+      expect(connection_manager.fetch_connection(false)).to be_kind_of(Fog::Brightbox::Compute::Real)
     end
 
     it "returns a connection without account scope" do

--- a/spec/unit/brightbox/database_server/cloud_ips_spec.rb
+++ b/spec/unit/brightbox/database_server/cloud_ips_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "fog/brightbox/models/compute/database_server"
 
 describe Brightbox::DatabaseServer, "#cloud_ips" do
-  let(:fog_model) { Fog::Compute::Brightbox::DatabaseServer.new(fog_settings) }
+  let(:fog_model) { Fog::Brightbox::Compute::DatabaseServer.new(fog_settings) }
   let(:dbs) { described_class.new(fog_model) }
 
   context "when attribute is missing" do

--- a/spec/unit/brightbox/database_server/maintenance_window_spec.rb
+++ b/spec/unit/brightbox/database_server/maintenance_window_spec.rb
@@ -4,7 +4,7 @@ require "fog/brightbox/models/compute/database_server"
 describe Brightbox::DatabaseServer do
 
   describe "#maintenance_window" do
-    let(:fog_model) { Fog::Compute::Brightbox::DatabaseServer.new(fog_settings) }
+    let(:fog_model) { Fog::Brightbox::Compute::DatabaseServer.new(fog_settings) }
     let(:dbs) { Brightbox::DatabaseServer.new(fog_model) }
 
     context "when default values" do

--- a/spec/unit/brightbox/user_collaboration/get_for_account_spec.rb
+++ b/spec/unit/brightbox/user_collaboration/get_for_account_spec.rb
@@ -141,7 +141,7 @@ describe Brightbox::UserCollaboration do
       # Collection#load is private in fog so we can't just pass our collection
       # into get the correct object initialised.
       api_response_data.map do |datum|
-        Fog::Compute::Brightbox::UserCollaboration.new(datum)
+        Fog::Brightbox::Compute::UserCollaboration.new(datum)
       end
     end
   end

--- a/spec/unit/brightbox/user_collaboration/remove_spec.rb
+++ b/spec/unit/brightbox/user_collaboration/remove_spec.rb
@@ -52,6 +52,6 @@ describe Brightbox::UserCollaboration do
         "email_address" => "marie@example.com"
       }
     }
-    Fog::Compute::Brightbox::UserCollaboration.new(api_response_data)
+    Fog::Brightbox::Compute::UserCollaboration.new(api_response_data)
   end
 end


### PR DESCRIPTION
This is an overdue major update to use `fog-brightbox v1.1.0`.

The update includes a backwards incompatible standardising of module
names from `Fog::Compute::Brightbox` to our own `Fog::Brightbox`
namespace pushed from `fog-core`