### PR TITLE
Bump `rspec` from 2.99 to 3.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     coderay (1.0.9)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
-    diff-lcs (1.2.5)
+    diff-lcs (1.4.3)
     dry-inflector (0.1.2)
     excon (0.75.0)
     fog-brightbox (1.1.0)
@@ -53,14 +53,19 @@ GEM
       pry (~> 0.9)
       slop (~> 3.0)
     rake (10.1.0)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.1)
-    rspec-expectations (2.99.1)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.99.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
     safe_yaml (1.0.4)
     slop (3.4.5)
     vcr (2.5.0)
@@ -76,7 +81,7 @@ DEPENDENCIES
   mocha
   pry-remote
   rake
-  rspec (~> 2.99)
+  rspec
   vcr (~> 2.5)
   webmock
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,5 @@
-require "bundler"
 require "rspec/core/rake_task"
 
-bbcloud_path = File.expand_path("./lib", File.dirname(__FILE__))
-$LOAD_PATH.unshift(bbcloud_path)
+RSpec::Core::RakeTask.new(:spec)
 
-task :default => [:test]
-
-Bundler::GemHelper.install_tasks
-
-RSpec::Core::RakeTask.new
-
-desc "Runs all tests (rspec and cucumber)"
-task :test do
-  Rake::Task["spec"].invoke
-end
+task :default => :spec

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-remote"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 2.99"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "vcr", "~> 2.5"
   s.add_development_dependency "webmock"
 


### PR DESCRIPTION
Updating `rake` catches an issue where the earlier versions of RSpec
and its Rake task would reference `last_comment` which was removed from
Rake.

So to enable that RSpec needs updating.