### PR TITLE
Add `ssl-min-ver` argument to `lbs`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (3.0.1)
       dry-inflector (< 0.2)
-      fog-brightbox (>= 1.1.0)
+      fog-brightbox (>= 1.2.0)
       fog-core (< 2.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
@@ -22,8 +22,8 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.4.3)
     dry-inflector (0.1.2)
-    excon (0.75.0)
-    fog-brightbox (1.1.0)
+    excon (0.78.0)
+    fog-brightbox (1.2.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.1.0"
+  s.add_dependency "fog-brightbox", ">= 1.2.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"

--- a/lib/brightbox-cli/commands/lbs/create.rb
+++ b/lib/brightbox-cli/commands/lbs/create.rb
@@ -52,6 +52,10 @@ module Brightbox
       c.desc "Filepath to the private key used to sign SSL certificate (OpenSSL supported formats)."
       c.flag ["ssl-key"]
 
+      c.desc "Sets the minimum version of TLS/SSL to support in the format 'TLSv1.x'"
+      c.default_value "TLSv1.2"
+      c.flag ["ssl-min-ver"]
+
       c.desc "Enable SSL v3 support"
       c.switch ["sslv3"]
 
@@ -118,6 +122,7 @@ module Brightbox
                                  :listeners => listeners,
                                  :certificate_pem => ssl_cert,
                                  :certificate_private_key => ssl_key,
+                                 :ssl_minimum_version => options["ssl-min-ver"],
                                  :sslv3 => options["sslv3"],
                                  :nodes => nodes)
         render_table([lb], global_options)

--- a/lib/brightbox-cli/commands/lbs/show.rb
+++ b/lib/brightbox-cli/commands/lbs/show.rb
@@ -18,6 +18,7 @@ module Brightbox
             :created_at,
             :deleted_at,
             :policy,
+            :ssl_minimum_version,
             :ssl_issuer,
             :ssl_subject,
             :ssl_valid_from,

--- a/lib/brightbox-cli/commands/lbs/update.rb
+++ b/lib/brightbox-cli/commands/lbs/update.rb
@@ -45,6 +45,9 @@ module Brightbox
       c.desc "Filepath to the private key used to sign SSL certificate (OpenSSL supported formats)."
       c.flag ["ssl-key"]
 
+      c.desc "Sets the minimum version of TLS/SSL to support in the format 'TLSv1.x'"
+      c.flag ["ssl-min-ver"]
+
       c.desc "Clears SSL details from the load balancer."
       c.switch ["remove-ssl"], :negatable => false
 
@@ -126,6 +129,10 @@ module Brightbox
         if remove_ssl
           lbopts[:certificate_pem] = ""
           lbopts[:certificate_private_key] = ""
+        end
+
+        if options["ssl-min-ver"]
+          lbopts[:ssl_minimum_version] = options["ssl-min-ver"] unless options["ssl-min-ver"].nil?
         end
 
         lbopts.nilify_blanks

--- a/lib/brightbox-cli/load_balancers.rb
+++ b/lib/brightbox-cli/load_balancers.rb
@@ -12,6 +12,7 @@ module Brightbox
     def to_row
       attributes.merge(
         :locked => locked?,
+        :ssl_minimum_version => ssl_minimum_version,
         :ssl_issuer => certificate_issuer,
         :ssl_subject => certificate_subject,
         :ssl_valid_from => certificate_valid_from,

--- a/spec/commands/lbs/create_spec.rb
+++ b/spec/commands/lbs/create_spec.rb
@@ -7,11 +7,42 @@ describe "brightbox lbs" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
+    before do
+      config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+      cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
+    end
+
     context "" do
       let(:argv) { %w(lbs create) }
 
       it "does not error" do
         expect { output }.to_not raise_error
+      end
+    end
+
+    context "--ssl-min-ver=TLSv1.0" do
+      let(:argv) { ["lbs", "create", "--ssl-min-ver", "TLSv1.0", "srv-12345"] }
+      let(:expected_args) { { ssl_minimum_version: "TLSv1.0" } }
+
+      let(:json_response) do
+        <<-EOS
+        {
+          "id":"lba-12345",
+          "ssl_minimum_version":"TLSv1.0"
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:post, "http://api.brightbox.dev/1.0/load_balancers?account_id=acc-12345")
+          .with(:body => hash_including("ssl_minimum_version" => "TLSv1.0"))
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "includes ssl_minimum_version in response" do
+        expect(Brightbox::LoadBalancer).to receive(:create).with(hash_including(expected_args)).and_call_original
+        expect(stderr).to eq("Creating a new load balancer\n")
+        expect(stdout).to include("lba-12345")
       end
     end
   end

--- a/spec/commands/lbs/update_spec.rb
+++ b/spec/commands/lbs/update_spec.rb
@@ -7,11 +7,43 @@ describe "brightbox lbs" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
+    before do
+      config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+      cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
+    end
+
     context "" do
       let(:argv) { %w(lbs update) }
 
       it "does not error" do
         expect { output }.to_not raise_error
+      end
+    end
+
+    context "--ssl-min-ver=TLSv1.0" do
+      let(:argv) { ["lbs", "update", "--ssl-min-ver", "TLSv1.0", "lba-12345"] }
+
+      let(:json_response) do
+        <<-EOS
+        {
+          "id":"lba-12345",
+          "ssl_minimum_version":"TLSv1.0"
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.dev/1.0/load_balancers/lba-12345?account_id=acc-12345")
+          .to_return(:status => 200, :body => '{"id":"lba-12345"}')
+
+        stub_request(:put, "http://api.brightbox.dev/1.0/load_balancers/lba-12345?account_id=acc-12345")
+          .with(:body => hash_including("ssl_minimum_version" => "TLSv1.0"))
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "includes ssl_minimum_version in response" do
+        expect(stderr).to eq("Updating load balancer lba-12345\n")
+        expect(stdout).to include("lba-12345")
       end
     end
   end


### PR DESCRIPTION
The `ssl-min-ver` command can now set the minimum TLS/SSL version that
should be supported by the load balancer.

    brightbox lbs create --ssl-min-ver TLSv1.0

TLSv1.0 is dated and whilst it has widest compatibily a number of
security vulnerability affect it. As does TLS1.1

TLSv1.2 is the default whilst TLSv1.3 is also supported.