### PR TITLE
Add `servers --disk-encrypted` switch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (3.1.0)
       dry-inflector (< 0.2)
-      fog-brightbox (>= 1.2.0)
+      fog-brightbox (>= 1.3.0)
       fog-core (< 2.0)
       gli (~> 2.12.0)
       highline (~> 1.6.0)
@@ -23,7 +23,7 @@ GEM
     diff-lcs (1.4.3)
     dry-inflector (0.1.2)
     excon (0.78.0)
-    fog-brightbox (1.2.0)
+    fog-brightbox (1.3.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.2.0"
+  s.add_dependency "fog-brightbox", ">= 1.3.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.12.0"
   s.add_dependency "i18n", "~> 0.6.0"

--- a/lib/brightbox-cli/commands/servers/create.rb
+++ b/lib/brightbox-cli/commands/servers/create.rb
@@ -29,6 +29,10 @@ module Brightbox
       c.default_value true
       c.switch [:e, :base64], :negatable => true
 
+      c.desc "Enable encryption at rest for disk"
+      c.default_value false
+      c.switch ["disk-encrypted"], :negatable => false
+
       c.desc "Server groups to place server in - comma delimited list"
       c.flag [:g, "server-groups"]
 
@@ -116,6 +120,7 @@ module Brightbox
         }
 
         params[:cloud_ip] = options[:"cloud-ip"] if options.key?(:"cloud-ip")
+        params[:disk_encrypted] = options[:"disk-encrypted"] if options.key?(:"disk-encrypted")
 
         servers = Server.create_servers options[:i], params
         render_table(servers, global_options)

--- a/lib/brightbox-cli/detailed_server.rb
+++ b/lib/brightbox-cli/detailed_server.rb
@@ -49,6 +49,7 @@ module Brightbox
         :ram,
         :cores,
         :disk,
+        :disk_encrypted,
         :compatibility_mode,
         :image,
         :image_name,


### PR DESCRIPTION
This can be used to request encryption at rest for new server builds
where a LUKS volume is used to ensure the disk image is encrypted.