### PR TITLE
Expand Ruby versions tested

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.4", "2.5", "2.6", "2.7"]
+        ruby: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Due to a mix up of documentation, it appears a wider range of Ruby
versions can be used for testing than first understood.

This adds testing back to Ruby 2.1.