### PR TITLE
Replace `.dev` subdomain as default for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changes:
 * Updates `webmock` from 1.21.0 to 3.14.0
 * Removes `rubyforge` reference from gemspec to remove deprecation warning
 * Remove post install message from gemspec
+* Updated `.dev` TLD used in testing to `.localhost` to avoid problems when the
+  original was commercialised such as local DNS blocked by browsers.
 
 ### v3.3.0 / 2021-09-17
 

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_a_collection_of_Accounts.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_a_collection_of_Accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:38 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -90,7 +90,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:38 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:38 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -177,7 +177,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:42 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_resources_on_the_same_connection.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_application/returns_resources_on_the_same_connection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:39 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_a_collection_of_Accounts.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_a_collection_of_Accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:39 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:39 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -136,7 +136,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_resources_on_the_same_connection.yml
+++ b/spec/cassettes/Brightbox_Account/_all/when_connected_using_an_client/returns_resources_on_the_same_connection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:39 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_false/does_not_update_the_config_file.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_false/does_not_update_the_config_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"64f68b5dddea1c6b774286180375ba883b896cac","token_type":"Bearer","refresh_token":"b7716ed2480d2831c8cb8af8ea536666c27815b1","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,11 +96,11 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"b7716ed2480d2831c8cb8af8ea536666c27815b1"}'
@@ -114,7 +114,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -144,11 +144,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"c8975689c865aafc885cf964a76fa72418451e25","token_type":"Bearer","refresh_token":"9f7921dbea20637a80b117f3e677060831b6522d","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -162,7 +162,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -194,6 +194,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:34:22 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_true/does_not_update_the_config_file.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_config_exists_and_overwrite_duplicates_is_true/does_not_update_the_config_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"13824deca216ba81d5963d75659755d76083c490","token_type":"Bearer","refresh_token":"6b70b12f95df7b7e95e6cf0a99e5982ea7087f2c","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,11 +96,11 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"6b70b12f95df7b7e95e6cf0a99e5982ea7087f2c"}'
@@ -114,7 +114,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -144,11 +144,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"9f1758514b2245dc6d52c550d252074287277e7b","token_type":"Bearer","refresh_token":"514aa63f8de3113429e721e117cc60f5a6e2e004","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -162,7 +162,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -194,6 +194,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-09-29T08:22:15Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-09-29T08:22:15Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Wed, 30 Sep 2015 14:55:23 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_changes_to_the_config_file.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_changes_to_the_config_file.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:09:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_default_account.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_default_account.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:09:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_new_client_as_the_default.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_add_section/when_first_and_only_client/saves_the_new_client_as_the_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:09:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_is_not_authenticated/does_not_raise_an_error.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_is_not_authenticated/does_not_raise_an_error.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -40,7 +40,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:40 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -81,7 +81,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -124,7 +124,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:09:15 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -161,7 +161,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:41 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -204,7 +204,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:41 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -241,7 +241,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:41 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -284,7 +284,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:10 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_may_access_one_account/updates_the_setting.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_find_or_set_default_account/when_client_may_access_one_account/updates_the_setting.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -40,7 +40,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:40 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -81,7 +81,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -124,7 +124,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:08:24 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -161,7 +161,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:41 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -204,7 +204,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:41 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -241,7 +241,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:41 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -284,7 +284,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:10 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_config_in_use_is_not_the_default/uses_correct_credentials.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_config_in_use_is_not_the_default/uses_correct_credentials.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_a_cached_refresh_token/caches_the_new_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_a_cached_refresh_token/caches_the_new_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"aeed54b3487019931b04010b0b39715eb4e729e8"}'

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_an_expired_refresh_token/caches_the_new_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_an_expired_refresh_token/caches_the_new_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"aeed54b3487019931b04010b0b39715eb4e729e8"}'
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 11:11:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/caches_the_new_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/caches_the_new_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/prompts_user_to_retry_command.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_a_user_app_with_no_tokens/prompts_user_to_retry_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'

--- a/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_an_API_client_with_no_tokens/caches_a_new_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig/_renew_tokens/when_using_an_API_client_with_no_tokens/caches_a_new_access_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/does_not_alter_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/does_not_alter_the_configuration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"d3d51356b662040aa9b0e4bf162409b4ea879aab","token_type":"Bearer","refresh_token":"7c72c3b5d05b61b21e9795919b236c1563496a40","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"7c72c3b5d05b61b21e9795919b236c1563496a40"}'
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -94,6 +94,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"9007643d343038066570caa040c929d19a9826e1","token_type":"Bearer","refresh_token":"a6403aaf3bc717aeadeae2f78bf8182bdd6e565e","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_access_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"9aa043fa1343df86b7288c405d077674faf5943b","token_type":"Bearer","refresh_token":"4ce512422f6551fe7358aba6781c9c2270486805","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"4ce512422f6551fe7358aba6781c9c2270486805"}'
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -94,6 +94,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"2eea36047cea590f963d5ac76e6a73d8e62e9738","token_type":"Bearer","refresh_token":"34019e0aaf024580dd0e4c46f81113b39e191085","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_refresh_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_altering_a_custom_option/updates_refresh_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"7511af8bbea2b6f214fc358d9aef90f4b31702e3","token_type":"Bearer","refresh_token":"87ee62bc09a7fe69e96c8c07fd61c9c9019de180","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"87ee62bc09a7fe69e96c8c07fd61c9c9019de180"}'
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -94,6 +94,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"fe0c22e0855f692a06bfdf712ec2508e2e5b1d24","token_type":"Bearer","refresh_token":"ea1a800fd63fec3b8ff2dc9b96837fe68a54a928","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/does_not_alter_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/does_not_alter_the_configuration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"2a0dc3e96bb4c077b71425e5f20a7fe4323cb967","token_type":"Bearer","refresh_token":"581e7ac10e16b21a6375503509b55c183c6f52ce","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"581e7ac10e16b21a6375503509b55c183c6f52ce"}'
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -94,6 +94,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"55e733e1e4f06bb8dcca957409b2ec4edeadba44","token_type":"Bearer","refresh_token":"27fb8e6765cd6987710d6044d9745ce735a5cb14","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_access_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"bd7acf61bdbad602e74951f62102cd0d61532277","token_type":"Bearer","refresh_token":"8a53a8103f3e90fc9b895f3afb34d875cba18c0b","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"8a53a8103f3e90fc9b895f3afb34d875cba18c0b"}'
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -94,6 +94,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"437d4e29c60acf9b2f08cff31bc384c48ae2d1a4","token_type":"Bearer","refresh_token":"25980c2a6eb9a834bb4d42ea16b902ef7dd3b651","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_refresh_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_configured_with_custom_options/updates_refresh_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"aa418baea89052f46b3a64e6f70808ee74ef3edb","token_type":"Bearer","refresh_token":"7576198c29eb4bef281c9c37d367dc93682c98d0","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"7576198c29eb4bef281c9c37d367dc93682c98d0"}'
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -94,6 +94,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"c050b5cf9e9dceb65892a7d492518cfb0ff0e912","token_type":"Bearer","refresh_token":"7b88a20eb4a1e5efb66daa809202ccca4a6b0dc1","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:20 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/does_not_alter_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/does_not_alter_the_configuration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"fb2b511bc41324b7661ff36a7147218f9c8fdd7d","token_type":"Bearer","refresh_token":"d6e06d34b77c525ebbd4d5ac10156c71461be803","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,11 +96,11 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"d6e06d34b77c525ebbd4d5ac10156c71461be803"}'
@@ -114,7 +114,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -144,6 +144,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"ff8ee8c3ec7e5d2b56bd8a0b278fe7fe2957c760","token_type":"Bearer","refresh_token":"054b814f6c87c6867389468e71563822beb102ed","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_access_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_access_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"ba308ca0d6c436138d08273efb3e4dcc94316c29","token_type":"Bearer","refresh_token":"3aac6c150ea7b2712df3134375359ced3ab18a64","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,11 +96,11 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"3aac6c150ea7b2712df3134375359ced3ab18a64"}'
@@ -114,7 +114,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -144,6 +144,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"9ce76a11968b0945fef107e70e21e0224d1eb8c6","token_type":"Bearer","refresh_token":"f54a157a62fd86c8b6be7458c8dcd91875d0831d","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_refresh_token.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_logged_in_previously/updates_refresh_token.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"3b80108be0152c2d31575574027de1b9807fc971","token_type":"Bearer","refresh_token":"536bd861231e153f11893399ecbb6b417adbb0a3","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,11 +96,11 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"536bd861231e153f11893399ecbb6b417adbb0a3"}'
@@ -114,7 +114,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -144,6 +144,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"73e0ea46b6067aaba435ef21ac0c9f18b185a162","token_type":"Bearer","refresh_token":"8de93966cb2092de010c68939cb2da3aac74924e","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/creates_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/creates_the_configuration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"cd64dd737e020f9975a97c35e78e27e46442eb27","token_type":"Bearer","refresh_token":"00114bd8f6aa955911870efbb5f8b135dc6fc9c5","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/refreshed_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_no_config_exists/refreshed_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"f1d7a05784f9bea5060fbcc4a9a46d5b6cf05dbe","token_type":"Bearer","refresh_token":"5b891e0affc1fa7d9e5462482e07f6bf3c0ad21f","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/creates_the_configuration.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/creates_the_configuration.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"cd64dd737e020f9975a97c35e78e27e46442eb27","token_type":"Bearer","refresh_token":"00114bd8f6aa955911870efbb5f8b135dc6fc9c5","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/refreshed_tokens.yml
+++ b/spec/cassettes/Brightbox_BBConfig_add_login/when_using_an_email_and_suffix/refreshed_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"f1d7a05784f9bea5060fbcc4a9a46d5b6cf05dbe","token_type":"Bearer","refresh_token":"5b891e0affc1fa7d9e5462482e07f6bf3c0ad21f","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 11:34:18 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/Brightbox_CloudIP/_find_all_/when_a_Cloud_IP_exists/returns_a_suitable.yml
+++ b/spec/cassettes/Brightbox_CloudIP/_find_all_/when_a_Cloud_IP_exists/returns_a_suitable.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:40 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/cloud_ips?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/cloud_ips/cip-bjn8m
+      - http://api.brightbox.localhost/1.0/cloud_ips/cip-bjn8m
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:41 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:41 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -166,7 +166,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:41 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -205,7 +205,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:41 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -250,7 +250,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:54:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -294,7 +294,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:04 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -338,7 +338,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:04 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -382,7 +382,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:04 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -426,7 +426,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:04 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -470,7 +470,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:04 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -510,7 +510,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:42 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -555,7 +555,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:42 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallPolicy/_apply_to/should_apply_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_apply_to/should_apply_firewall_policy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:42 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/server_groups?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"name":"rspec_tests_apply"}'
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/server_groups/grp-ap00b
+      - http://api.brightbox.localhost/1.0/server_groups/grp-ap00b
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:42 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"name":"rspec_firewall_policy_apply"}'
@@ -103,7 +103,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-7t04w
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-7t04w
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:42 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345/apply_to?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345/apply_to?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"server_group":"grp-12345"}'
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:43 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/server_groups/grp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups/grp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -201,7 +201,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -289,7 +289,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -333,7 +333,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -377,7 +377,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -421,7 +421,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -466,7 +466,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:42 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallPolicy/_create/should_create_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_create/should_create_firewall_policy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/server_groups?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"name":"rspec_tests"}'
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/server_groups/grp-13tm6
+      - http://api.brightbox.localhost/1.0/server_groups/grp-13tm6
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"server_group":"grp-12345","name":"rspec_firewall_policy"}'
@@ -103,7 +103,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-zpofc
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-zpofc
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:43 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/server_groups/grp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups/grp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:44 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -208,7 +208,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -252,7 +252,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -296,7 +296,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -340,7 +340,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -385,7 +385,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:15:06 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -425,7 +425,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -470,7 +470,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:43 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallPolicy/_destroy/should_destroy_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_destroy/should_destroy_firewall_policy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:44 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/server_groups?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"name":"rspec_tests"}'
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/server_groups/grp-cuzfw
+      - http://api.brightbox.localhost/1.0/server_groups/grp-cuzfw
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:44 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"server_group":"grp-12345","name":"rspec_firewall_policy"}'
@@ -103,7 +103,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-pz9wl
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-pz9wl
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:44 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:45 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/server_groups/grp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups/grp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -201,7 +201,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -289,7 +289,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -333,7 +333,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -377,7 +377,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -421,7 +421,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -466,7 +466,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:15:11 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -506,7 +506,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -551,7 +551,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:43 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallPolicy/_find_all_/when_a_policy_exists/should_list_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_find_all_/when_a_policy_exists/should_list_firewall_policy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-gn8rf
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-gn8rf
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:46 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -129,7 +129,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:46 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -166,7 +166,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -254,7 +254,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -298,7 +298,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -342,7 +342,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -387,7 +387,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:08:18 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -427,7 +427,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:44 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -472,7 +472,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:44 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallPolicy/_find_or_call/when_a_policy_exists/should_show_firewall_policy.yml
+++ b/spec/cassettes/Brightbox_FirewallPolicy/_find_or_call/when_a_policy_exists/should_show_firewall_policy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-x59xt
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-x59xt
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:45 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:45 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -208,7 +208,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -252,7 +252,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -296,7 +296,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -340,7 +340,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -385,7 +385,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:44 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallRule/_create/when_policy_exists/creates_the_rule_successfully.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_create/when_policy_exists/creates_the_rule_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-vwj4g
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-vwj4g
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_rules?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"firewall_policy":"fwp-12345","protocol":"tcp","destination":"0.0.0.0/0","destination_port":"1080"}'
@@ -105,7 +105,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_rules/fwr-ih86j
+      - http://api.brightbox.localhost/1.0/firewall_rules/fwr-ih86j
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:47 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_rules/fwr-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules/fwr-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:47 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -201,7 +201,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -289,7 +289,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -333,7 +333,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -377,7 +377,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -421,7 +421,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -466,7 +466,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:44 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallRule/_destroy/when_rule_exists/destroys_a_rule.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_destroy/when_rule_exists/destroys_a_rule.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-4ib6v
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-4ib6v
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_rules?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"firewall_policy":"fwp-12345","protocol":"tcp","destination":"0.0.0.0/0","destination_port":"1080"}'
@@ -105,7 +105,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_rules/fwr-ixgd5
+      - http://api.brightbox.localhost/1.0/firewall_rules/fwr-ixgd5
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:48 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_rules/fwr-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules/fwr-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -208,7 +208,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -252,7 +252,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -296,7 +296,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -340,7 +340,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -385,7 +385,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:45 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallRule/_find/when_rule_exists/can_display_the_result.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_find/when_rule_exists/can_display_the_result.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-sz51p
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-sz51p
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_rules?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"firewall_policy":"fwp-12345","protocol":"tcp","destination":"0.0.0.0/0","destination_port":"1080"}'
@@ -105,7 +105,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_rules/fwr-6q2f6
+      - http://api.brightbox.localhost/1.0/firewall_rules/fwr-6q2f6
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:49 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/firewall_rules/fwr-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules/fwr-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -166,7 +166,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -254,7 +254,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -298,7 +298,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -342,7 +342,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -387,7 +387,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:26 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -427,7 +427,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -472,7 +472,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:45 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_FirewallRule/_from_policy/when_policy_exists_with_a_rule/lists_all_rules.yml
+++ b/spec/cassettes/Brightbox_FirewallRule/_from_policy/when_policy_exists_with_a_rule/lists_all_rules.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_policies?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_policies/fwp-9rgly
+      - http://api.brightbox.localhost/1.0/firewall_policies/fwp-9rgly
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_rules?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"firewall_policy":"fwp-12345","protocol":"tcp","destination":"0.0.0.0/0","destination_port":"1080"}'
@@ -105,7 +105,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_rules/fwr-huqjn
+      - http://api.brightbox.localhost/1.0/firewall_rules/fwr-huqjn
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/firewall_rules?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_rules?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"firewall_policy":"fwp-12345","protocol":"tcp","destination":"0.0.0.0/0","destination_port":"1081"}'
@@ -144,7 +144,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/firewall_rules/fwr-vmz5n
+      - http://api.brightbox.localhost/1.0/firewall_rules/fwr-vmz5n
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -166,7 +166,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -205,7 +205,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:50 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -242,7 +242,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -286,7 +286,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -330,7 +330,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -374,7 +374,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -418,7 +418,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -462,7 +462,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -506,7 +506,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -551,7 +551,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 11:21:48 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -591,7 +591,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -636,7 +636,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:45 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_destroy/when_server_exists/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_destroy/when_server_exists/should_work.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/server_types?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_types?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:51 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345","name":"wow","server_type":"typ-12345"}'
@@ -103,7 +103,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-cuso5
+      - http://api.brightbox.localhost/1.0/servers/srv-cuso5
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -126,7 +126,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:52 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -170,7 +170,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:55 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -214,7 +214,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:55 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -258,7 +258,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -303,7 +303,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:08:32 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -343,7 +343,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -388,7 +388,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:46 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_find_all_/when_a_server_exists/should_print_server_list.yml
+++ b/spec/cassettes/Brightbox_Server/_find_all_/when_a_server_exists/should_print_server_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345"}'
@@ -65,7 +65,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-gf3ig
+      - http://api.brightbox.localhost/1.0/servers/srv-gf3ig
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:00 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -137,7 +137,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:01 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -177,7 +177,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:02 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -215,7 +215,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -259,7 +259,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -303,7 +303,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -347,7 +347,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -391,7 +391,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:51 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -435,7 +435,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:51 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -480,7 +480,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:08:47 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -520,7 +520,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -565,7 +565,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:47 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_show/when_server_exists/shows_detailed_attributes_of_a_server.yml
+++ b/spec/cassettes/Brightbox_Server/_show/when_server_exists/shows_detailed_attributes_of_a_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:52 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345","name":"medium servers","server_type":"typ-12345"}'
@@ -64,7 +64,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-m8jo6
+      - http://api.brightbox.localhost/1.0/servers/srv-m8jo6
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:55 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -129,7 +129,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:55 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/images/img-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/images/img-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -168,7 +168,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:56 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/images/img-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/images/img-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:56 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/images/img-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/images/img-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -246,7 +246,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -291,7 +291,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:07:21 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -335,7 +335,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:54 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -379,7 +379,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:54 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -423,7 +423,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:55 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -467,7 +467,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:55 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -511,7 +511,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:55 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -555,7 +555,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:55 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -595,7 +595,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -640,7 +640,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:46 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_shutdown/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_shutdown/should_work.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:03 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/server_types?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_types?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -87,7 +87,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:04 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345","name":"rspec_server_shutdown","server_type":"typ-12345"}'
@@ -104,7 +104,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-nfz5c
+      - http://api.brightbox.localhost/1.0/servers/srv-nfz5c
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:55 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:56 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345/shutdown?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345/shutdown?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -289,7 +289,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:01 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -333,7 +333,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:01 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -377,7 +377,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:02 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -421,7 +421,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:02 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -465,7 +465,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -509,7 +509,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -554,7 +554,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:20:46 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -594,7 +594,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -639,7 +639,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:47 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_start/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_start/should_work.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/server_types?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_types?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -87,7 +87,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:13:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345","name":"rspec_server_start","server_type":"typ-12345"}'
@@ -104,7 +104,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-dilm5
+      - http://api.brightbox.localhost/1.0/servers/srv-dilm5
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:02 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:02 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:04 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345/stop?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345/stop?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:04 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -285,7 +285,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:05 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -325,7 +325,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:06 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345/start?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345/start?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -363,7 +363,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:06 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -407,7 +407,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -451,7 +451,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -495,7 +495,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -539,7 +539,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:43 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -583,7 +583,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:44 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -627,7 +627,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -671,7 +671,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:45 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -715,7 +715,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -759,7 +759,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -804,7 +804,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:09:33 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -844,7 +844,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -889,7 +889,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:03 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_stop/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_stop/should_work.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:07 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/server_types?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_types?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -87,7 +87,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:07 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345","name":"rspec_server_stop","server_type":"typ-12345"}'
@@ -104,7 +104,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-p0bg5
+      - http://api.brightbox.localhost/1.0/servers/srv-p0bg5
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:13 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -167,7 +167,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:14 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:16 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -247,7 +247,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:17 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345/stop?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345/stop?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -285,7 +285,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:18 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -329,7 +329,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:51 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -373,7 +373,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:52 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -417,7 +417,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:52 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -461,7 +461,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:52 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -505,7 +505,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:53 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -549,7 +549,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:54 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -593,7 +593,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:54 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -638,7 +638,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:05 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_Server/_update/when_passing_new_group_membership/should_update_with_group.yml
+++ b/spec/cassettes/Brightbox_Server/_update/when_passing_new_group_membership/should_update_with_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:21 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:21 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"image":"img-12345"}'
@@ -109,7 +109,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/servers/srv-q47f4
+      - http://api.brightbox.localhost/1.0/servers/srv-q47f4
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/server_groups?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"name":"test"}'
@@ -149,7 +149,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/server_groups/grp-pclgw
+      - http://api.brightbox.localhost/1.0/server_groups/grp-pclgw
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -171,7 +171,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:22 GMT
 - request:
     method: put
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"server_groups":["grp-12345"]}'
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:25 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -249,7 +249,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:25 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -288,7 +288,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:25 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -327,7 +327,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:26 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -364,7 +364,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:12:26 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -408,7 +408,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -452,7 +452,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -496,7 +496,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -540,7 +540,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -584,7 +584,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -628,7 +628,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -672,7 +672,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -716,7 +716,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:09:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -756,7 +756,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:08 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -801,7 +801,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:08 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Brightbox_ServerGroup/_find_all_/when_a_group_exists/list_server_groups.yml
+++ b/spec/cassettes/Brightbox_ServerGroup/_find_all_/when_a_group_exists/list_server_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/account?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/server_groups?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
     body:
       encoding: UTF-8
       string: '{"name":"Test group"}'
@@ -65,7 +65,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/server_groups/grp-dz0s6
+      - http://api.brightbox.localhost/1.0/server_groups/grp-dz0s6
       Content-Type:
       - application/json; charset=utf-8
       X-UA-Compatible:
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:19 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/server_groups?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:20 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.dev/1.0/server_groups/grp-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/server_groups/grp-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:14:20 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -214,7 +214,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -258,7 +258,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:00 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -302,7 +302,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:01 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -346,7 +346,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 17:10:01 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -391,7 +391,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 16:10:20 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -431,7 +431,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:08 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -476,7 +476,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:08:08 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/Firewall_policies/update/when_the_policy_does_not_exist/prints_error_to_STDERR.yml
+++ b/spec/cassettes/Firewall_policies/update/when_the_policy_does_not_exist/prints_error_to_STDERR.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345
     body:
       encoding: UTF-8
       string: ! '{"name":"missing"}'
@@ -50,7 +50,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:18:18 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: ! '{"grant_type":"client_credentials"}'
@@ -106,7 +106,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:18:18 GMT
 - request:
     method: put
-    uri: http://api.brightbox.dev/1.0/firewall_policies/fwp-12345
+    uri: http://api.brightbox.localhost/1.0/firewall_policies/fwp-12345
     body:
       encoding: ASCII-8BIT
       string: !binary |-

--- a/spec/cassettes/brightbox_accounts/list/_when_access_token_expired_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_access_token_expired_/does_not_report_invalid_token_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 401
-      message: 
+      message:
     headers:
       WWW-Authenticate:
       - OAuth error="invalid_token"
@@ -38,11 +38,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"invalid_token","error_description":"The OAuth token can not
         be found"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 28 Aug 2013 14:50:08 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -56,7 +56,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -84,11 +84,11 @@ http_interactions:
         provided is invalid, the client failed to authenticate, the client did not
         include its credentials, provided multiple client credentials, or used unsupported
         credentials type."}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 28 Aug 2013 14:50:08 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -102,7 +102,7 @@ http_interactions:
   response:
     status:
       code: 401
-      message: 
+      message:
     headers:
       WWW-Authenticate:
       - OAuth error="invalid_token"
@@ -124,11 +124,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"invalid_token","error_description":"The OAuth token can not
         be found"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 28 Aug 2013 14:50:08 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"a05c73351bbbc8d3abba9cf175733aec22a5cb71"}'
@@ -142,7 +142,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -169,11 +169,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"access_token":"d003e4f0970b948af8e35d3ed9f3531cdd6e2154","expires_in":7200,"refresh_token":"dcd32790159f852756dadf8bed12cc3369c7b448"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 28 Aug 2013 14:50:09 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -187,7 +187,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -215,11 +215,11 @@ http_interactions:
         provided is invalid, the client failed to authenticate, the client did not
         include its credentials, provided multiple client credentials, or used unsupported
         credentials type."}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 28 Aug 2013 14:54:24 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -233,7 +233,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -259,11 +259,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"unauthorized_client","error_description":"The authenticated
         client is not authorized to use the access grant type provided."}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 18 Sep 2013 15:18:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -277,7 +277,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -303,11 +303,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"unauthorized_client","error_description":"The authenticated
         client is not authorized to use the access grant type provided."}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 18 Sep 2013 15:18:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"a05c73351bbbc8d3abba9cf175733aec22a5cb71"}'
@@ -321,7 +321,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -349,11 +349,11 @@ http_interactions:
         is invalid, expired, or revoked (e.g. invalid assertion, expired authorization
         token, bad end-user password credentials, or mismatching authorization code
         and redirection URI)."}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 18 Sep 2013 15:19:02 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":""}'
@@ -367,7 +367,7 @@ http_interactions:
   response:
     status:
       code: 401
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -394,11 +394,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"error":"invalid_client"}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 18 Sep 2013 15:19:35 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"6846e655733a4fc36913c6c7e7bf8cb8fe7940b8"}'
@@ -412,7 +412,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -440,6 +440,6 @@ http_interactions:
         is invalid, expired, or revoked (e.g. invalid assertion, expired authorization
         token, bad end-user password credentials, or mismatching authorization code
         and redirection URI)."}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 19 Oct 2015 15:08:07 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_accounts/list/_when_both_tokens_expired_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_both_tokens_expired_/does_not_report_invalid_token_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:46:22 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:46:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -134,7 +134,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:46:22 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:46:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"b57a7c633a65614b74cc29839ccfade8e64e696d"}'
@@ -220,7 +220,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:46:23 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -265,7 +265,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:46:23 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -309,7 +309,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:18:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -353,7 +353,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:18:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"b57a7c633a65614b74cc29839ccfade8e64e696d"}'

--- a/spec/cassettes/brightbox_accounts/list/_when_invalid_tokens_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_invalid_tokens_/does_not_report_invalid_token_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -42,7 +42,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:18:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"c08bd7973ddf8493d878b22fe69c1044bbb3abb1"}'
@@ -87,7 +87,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:18:22 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:18:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"c08bd7973ddf8493d878b22fe69c1044bbb3abb1"}'
@@ -172,7 +172,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:18:27 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -217,7 +217,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:18:27 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -262,7 +262,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:19:48 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -308,7 +308,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 14:22:49 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -352,7 +352,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:18:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/does_not_report_invalid_token_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -42,11 +42,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"unauthorized_client","error_description":"The authenticated
         client is not authorized to use the access grant type provided."}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -60,7 +60,7 @@ http_interactions:
   response:
     status:
       code: 401
-      message: 
+      message:
     headers:
       WWW-Authenticate:
       - OAuth error="invalid_token"
@@ -82,11 +82,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"invalid_token","error_description":"The OAuth token can not
         be found"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -100,7 +100,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -126,11 +126,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"unauthorized_client","error_description":"The authenticated
         client is not authorized to use the access grant type provided."}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -144,7 +144,7 @@ http_interactions:
   response:
     status:
       code: 401
-      message: 
+      message:
     headers:
       WWW-Authenticate:
       - OAuth error="invalid_token"
@@ -166,11 +166,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"error":"invalid_token","error_description":"The OAuth token can not
         be found"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -184,7 +184,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -211,11 +211,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"access_token":"cf9d63fa39bf6f7bedad62c461f020e92d8f1e44","expires_in":7200,"refresh_token":"7b574d091da700939a4cebcd1938ad4b547b1d00"}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -229,7 +229,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -256,11 +256,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"access_token":"e75c77ba85740b2d572e15bbe75595ffc7f5814a","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Tue, 27 Aug 2013 16:54:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -274,7 +274,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -301,11 +301,11 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"access_token":"7e65f560ecbca978f15131faa5071d120b9986f2","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 28 Aug 2013 08:50:46 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"dcd32790159f852756dadf8bed12cc3369c7b448"}'
@@ -319,7 +319,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       X-Frame-Options:
       - sameorigin
@@ -347,11 +347,11 @@ http_interactions:
         is invalid, expired, or revoked (e.g. invalid assertion, expired authorization
         token, bad end-user password credentials, or mismatching authorization code
         and redirection URI)."}'
-    http_version: 
+    http_version:
   recorded_at: Wed, 18 Sep 2013 15:15:36 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"305ae4a60568a02d606744372dc7b8a2b80d7a8e"}'
@@ -365,7 +365,7 @@ http_interactions:
   response:
     status:
       code: 400
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -393,6 +393,6 @@ http_interactions:
         is invalid, expired, or revoked (e.g. invalid assertion, expired authorization
         token, bad end-user password credentials, or mismatching authorization code
         and redirection URI)."}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 19 Oct 2015 15:46:27 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/reports_they_were_updated.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_/reports_they_were_updated.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -130,7 +130,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -215,7 +215,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 15:11:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -260,7 +260,7 @@ http_interactions:
   recorded_at: Tue, 27 Aug 2013 16:54:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/does_not_report_invalid_token_errors.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/does_not_report_invalid_token_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:36 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -130,7 +130,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"wrong"}'
@@ -215,7 +215,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -260,7 +260,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:17:33 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/reports_unable_to_authenticate.yml
+++ b/spec/cassettes/brightbox_accounts/list/_when_no_tokens_and_password_incorrect_/reports_unable_to_authenticate.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -86,7 +86,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -130,7 +130,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -170,7 +170,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"wrong"}'
@@ -215,7 +215,7 @@ http_interactions:
   recorded_at: Wed, 18 Sep 2013 15:15:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/brightbox_accounts/list/does_not_error.yml
+++ b/spec/cassettes/brightbox_accounts/list/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 12:04:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       encoding: US-ASCII
       string: ''
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Wed, 28 Aug 2013 12:04:58 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'

--- a/spec/cassettes/brightbox_cloudips/map/when_destination_is_a_server_ID/passes_the_interface_identifier_to_the_API.yml
+++ b/spec/cassettes/brightbox_cloudips/map/when_destination_is_a_server_ID/passes_the_interface_identifier_to_the_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:59:06 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/servers/srv-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -91,7 +91,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:59:06 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345/map?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345/map?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"destination\":\"int-12345\"}"
@@ -133,7 +133,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:59:06 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -177,7 +177,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:59:07 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -221,7 +221,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:59:08 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -265,7 +265,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:59:09 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -311,7 +311,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:18 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -357,7 +357,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:18 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -403,7 +403,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:18 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -449,7 +449,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:18 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -495,7 +495,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:19 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_cloudips/map/when_destination_is_another_value/passes_the_identifier_to_the_API.yml
+++ b/spec/cassettes/brightbox_cloudips/map/when_destination_is_another_value/passes_the_identifier_to_the_API.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:55:03 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -90,7 +90,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:55:03 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:55:04 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -178,7 +178,7 @@ http_interactions:
   recorded_at: Tue, 21 Jan 2014 15:55:06 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -224,7 +224,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:22 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -270,7 +270,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 15:58:23 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/does_not_error.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:56 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -126,7 +126,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:57 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -163,7 +163,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:35 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -200,7 +200,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:35 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -243,7 +243,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:07 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_adding_a_new_client/sets_up_the_config.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:57 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -83,7 +83,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:57 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:35 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -163,7 +163,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:35 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -200,7 +200,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:36 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -243,7 +243,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:07 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_change_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_change_the_default_client.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:16:07 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -83,7 +83,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:16:07 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -163,7 +163,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:38 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -200,7 +200,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:38 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -243,7 +243,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:09 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/does_not_error.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:57 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -83,7 +83,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:36 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -163,7 +163,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:36 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -200,7 +200,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:36 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -243,7 +243,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:07 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -83,7 +83,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -163,7 +163,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:37 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -200,7 +200,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -243,7 +243,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:08 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/client_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
@@ -3,7 +3,7 @@ recorded_with: VCR 2.5.0
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/account
+    uri: http://api.brightbox.localhost/1.0/account
     body:
       string: ""
     headers:
@@ -83,7 +83,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 15:58:58 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:36 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -163,7 +163,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:36 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       string: ""
     headers:
@@ -200,7 +200,7 @@ http_interactions:
   recorded_at: Tue, 17 Sep 2013 17:07:37 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:
@@ -243,7 +243,7 @@ http_interactions:
   recorded_at: Fri, 27 Sep 2013 15:26:08 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       string: "{\"grant_type\":\"client_credentials\"}"
     headers:

--- a/spec/cassettes/brightbox_config/user_add/when_NO_config_file_on_disk/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_NO_config_file_on_disk/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 08:40:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -87,7 +87,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 08:40:50 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 08:40:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 08:40:52 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"946c0b873298d391f53f5b7d2751e6a735f6535c"}'

--- a/spec/cassettes/brightbox_config/user_add/when_a_default_client_is_already_set/does_not_change_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_a_default_client_is_already_set/does_not_change_the_default_client.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:13:52 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:33 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_details_in_config/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:33 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/display_an_warning_about_preselected_default.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/display_an_warning_about_preselected_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 10:19:09 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 10:19:09 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/selects_the_active_account_for_the_default.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/selects_the_active_account_for_the_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 10:19:09 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_only_one_active_account/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 10:19:09 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/display_an_warning_about_preselected_default.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/display_an_warning_about_preselected_default.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 13:38:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 13:38:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_application_has_access_to_multiple_accounts/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 13:38:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:30 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:29 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:28 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_this_as_the_default_client.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:32 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_new_client_is_first_and_only_client/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:27 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -87,7 +87,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:27 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -132,7 +132,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:27 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
   recorded_at: Fri, 06 Sep 2013 16:04:28 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"refresh_token","refresh_token":"ce9ca2cedece63cfc8ad646b13c187a5133b2d1e"}'

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:04 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:04 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:04 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:03 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"client_credentials"}'
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:03 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/does_not_error.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:06 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:05 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_config/user_add/when_passing_in_required_arguments_and_api_url/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Tue, 03 Sep 2013 10:38:05 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"f04583a23a52ebd80898bafd1e1025327fb97544","token_type":"Bearer","refresh_token":"b8efc70e9ab697d2ac19bb54efabf317239bb246","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/prompts_for_the_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"12249a52a3f5d7aa4912764e6e5d70c78ff664f3","token_type":"Bearer","refresh_token":"3b3245e1cdc86dfab023a80755c7d07c56c4d16e","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"67ba17bf0f2c8c8b5fbcdd27745ded8c8acd75a1","token_type":"Bearer","refresh_token":"7d0559c8de7546463a7fb3e608e234ba4b980aff","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:54 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_alternative_client_credentials_are_given/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"c8038e9c15ef8c53dcf1c746944c09283ad95c3b","token_type":"Bearer","refresh_token":"1e36d9917dc7ecfcbae82b35711746ceecbd602f","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"007db0c2d5319fe5c1699d77e41e3a279c53ff26","token_type":"Bearer","refresh_token":"6011155876a84e5a18f76522b8cec0d5bd95b936","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"e4d0e860186948c4fe5d46f6637e2d64f3d75a0b","token_type":"Bearer","refresh_token":"4ee0543818f24cc945944b30c7365a2995d3c467","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/prompts_for_the_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"e494b869f62c6d21d4fede766f4f33936ee3e50c","token_type":"Bearer","refresh_token":"1d69d988bc9fde48171ce7a90a2c141364e9781d","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"97f06bbe4ad27cca54d8f654f713458456d9f8e0","token_type":"Bearer","refresh_token":"e120ddcb3f6ed618cf3b4420b9c5d1e6f1557965","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_custom_api/auth_URLs_are_given/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"def6238f30ac65ee3f3aae7d61e39f17a3fcf9fd","token_type":"Bearer","refresh_token":"4e8bbe751340be8e33e336e83d9e3f18fbdb5587","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,6 +46,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"a5dcbaa16f20832bc6df0b709efacc624cd7e58b","token_type":"Bearer","refresh_token":"6577ac9f6c4c1176fd82b0eaf1dacc207b37f496","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,6 +46,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"070f61decf530b8159aa75d80e61fc0c157b1efb","token_type":"Bearer","refresh_token":"b2073600848dd5fa6ea69115dd96730330190fb3","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/prompts_for_the_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,6 +46,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"cf9042dc6082feee0390b00cdb4e6a0c08f74ca3","token_type":"Bearer","refresh_token":"0977441e798173b94028b76eaf6bcb6e08dafc8e","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:52 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,6 +46,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"a64a130f3a6f32529e539b3b0ba9cb0bd829160d","token_type":"Bearer","refresh_token":"c2239ef492e6d13d95c04e1f2ab7d99b16e0c202","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_default_account_is_passed/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_default_account_is_passed/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,6 +46,6 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"a555fa363cb14838b2efc870494ec6aa2360808b","token_type":"Bearer","refresh_token":"1a27aae58a7f3f185cb8fa75a0a150a3504a8606","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:53 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"17e9282e40b8a2f1366107a068a1632bb65d3dec","token_type":"Bearer","refresh_token":"b77913a13cccfdd44294b4b161494a652d48b635","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:49 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"a417c4c77d6c301799fd36a8056d5d806186cc60","token_type":"Bearer","refresh_token":"20c5df44e08169d0abfa0bca6de921a37d81c5ce","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"4e7c8dd40b841b806583f5b2cadcc691ab15be46","token_type":"Bearer","refresh_token":"da0effede233897c05dabe2924c39be9011012b7","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_config_is_present/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_no_config_is_present/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"affffc3b0161b9255914aaf4f598a15aa010df3f","token_type":"Bearer","refresh_token":"152ab03cbf105485a5a1ff64b189beeaff9cfad9","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_error.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"04e476fd543f333dc007196d76a6625d6570adf7","token_type":"Bearer","refresh_token":"2cafee59e2c2d6cf847c83161870351792376b6b","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_prompt_to_rerun_the_command.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/does_not_prompt_to_rerun_the_command.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"40b90180f48c7a3c6638f8175e2a34cc73b03b0f","token_type":"Bearer","refresh_token":"18b68b787ac0e33ad14c51eb7fbf5af1f4dc0ab2","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/prompts_for_the_password.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/prompts_for_the_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"b7e97a2c08221216f6f82ee05e1d9631446853bb","token_type":"Bearer","refresh_token":"7d845e3d6790e2888a36922302bdaf42c59207e7","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:50 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/requests_access_tokens.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/requests_access_tokens.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"0e2b6ecb38dc7edeecd010fdbb130dc81eed3244","token_type":"Bearer","refresh_token":"84e7fbdaee8490c190fcadb0d6e514bb0dd28f7b","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_login/when_no_password_is_given/sets_up_the_config.yml
+++ b/spec/cassettes/brightbox_login/when_no_password_is_given/sets_up_the_config.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: '{"grant_type":"password","username":"jason.null@brightbox.com","password":"N:B3e%7Cmh"}'
@@ -16,7 +16,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       Content-Type:
       - application/json
@@ -46,11 +46,11 @@ http_interactions:
       encoding: UTF-8
       string: '{"access_token":"b07faf14eafa2fd510bb7ef94aff0acfaaa3c70f","token_type":"Bearer","refresh_token":"83aa5702840aba673845a9b9bd35421065eb4d8f","scope":"infrastructure,
         orbit","expires_in":7200}'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/accounts
+    uri: http://api.brightbox.localhost/1.0/accounts
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   response:
     status:
       code: 200
-      message: 
+      message:
     headers:
       X-Oauth-Scopes:
       - infrastructure, orbit
@@ -96,6 +96,6 @@ http_interactions:
         new servers are added to this group unless specified otherwise.","created_at":"2015-10-12T09:23:03Z","default":true}],"firewall_policies":[{"id":"fwp-12345","resource_type":"firewall_policy","url":"https://api.gb1.brightbox.com/1.0/firewall_policies/fwp-12345","default":true,"name":"default","created_at":"2015-10-12T09:23:03Z","description":"Applied
         to the default server group."}],"owner":{"id":"usr-12345","resource_type":"user","url":"https://api.gb1.brightbox.com/1.0/users/usr-12345","name":"Jason
         Null","email_address":"jason.null@brightbox.com"},"users":[],"zones":[{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"},{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-b"}]}]'
-    http_version: 
+    http_version:
   recorded_at: Mon, 12 Oct 2015 14:53:51 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--allow-access_10_0_0_0/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--allow-access_10_0_0_0/correctly_sends_API_parameters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"name\":null,\"description\":null,\"allow_access\":[\"10.0.0.0\"],\"maintenance_weekday\":null,\"maintenance_hour\":null}"
@@ -19,7 +19,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/database_servers/dbs-w5r2e
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-w5r2e
       Content-Type:
       - application/json; charset=utf-8
       X-Ua-Compatible:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Feb 2014 17:02:16 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/create/--allow-access_srv-12345_grp-12345/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--allow-access_srv-12345_grp-12345/correctly_sends_API_parameters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"name\":null,\"description\":null,\"allow_access\":[\"srv-12345\",\"grp-12345\"],\"maintenance_weekday\":null,\"maintenance_hour\":null}"
@@ -19,7 +19,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/database_servers/dbs-el0py
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-el0py
       Content-Type:
       - application/json; charset=utf-8
       X-Ua-Compatible:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Feb 2014 17:02:30 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/create/--engine_mysql/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--engine_mysql/correctly_sends_API_parameters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null,\"engine\":\"mysql\"}"
@@ -19,7 +19,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/database_servers/dbs-pb9ag
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-pb9ag
       Content-Type:
       - application/json; charset=utf-8
       X-Ua-Compatible:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Feb 2014 17:04:30 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/create/--engine_mysql_--engine-version_5_6/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--engine_mysql_--engine-version_5_6/correctly_sends_API_parameters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null,\"engine\":\"mysql\",\"version\":\"5.6\"}"
@@ -19,7 +19,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/database_servers/dbs-kh13c
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-kh13c
       Content-Type:
       - application/json; charset=utf-8
       X-Ua-Compatible:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Feb 2014 17:08:29 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_password.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null}"
@@ -19,7 +19,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/database_servers/dbs-28vhw
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-28vhw
       Content-Type:
       - application/json; charset=utf-8
       X-Ua-Compatible:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Feb 2014 17:01:33 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_username.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_username.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
       string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null}"
@@ -19,7 +19,7 @@ http_interactions:
       message:
     headers:
       Location:
-      - http://api.brightbox.dev/1.0/database_servers/dbs-rqxs1
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-rqxs1
       Content-Type:
       - application/json; charset=utf-8
       X-Ua-Compatible:
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 19 Feb 2014 17:01:31 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/snapshot/when_database_server_active/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/snapshot/when_database_server_active/correctly_sends_API_parameters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Thu, 16 Jan 2014 15:29:56 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers/dbs-12345/snapshot?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-12345/snapshot?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -88,7 +88,7 @@ http_interactions:
   recorded_at: Thu, 16 Jan 2014 15:29:57 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"
@@ -134,7 +134,7 @@ http_interactions:
   recorded_at: Tue, 18 Feb 2014 17:30:26 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_instances/snapshot/when_database_server_can_not_be_snapshotted/reports_an_error_to_the_user.yml
+++ b/spec/cassettes/brightbox_sql_instances/snapshot/when_database_server_can_not_be_snapshotted/reports_an_error_to_the_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.dev/1.0/database_servers/dbs-12345/snapshot?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-12345/snapshot?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -44,7 +44,7 @@ http_interactions:
   recorded_at: Thu, 16 Jan 2014 15:30:27 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_snapshots/list/when_resources_are_available/does_not_output_to_stderr.yml
+++ b/spec/cassettes/brightbox_sql_snapshots/list/when_resources_are_available/does_not_output_to_stderr.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/database_snapshots?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_snapshots?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 17 Jan 2014 10:27:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_snapshots/list/when_resources_are_available/outputs_table_details_to_stdout.yml
+++ b/spec/cassettes/brightbox_sql_snapshots/list/when_resources_are_available/outputs_table_details_to_stdout.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/database_snapshots?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_snapshots?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 17 Jan 2014 10:27:47 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/cassettes/brightbox_sql_snapshots/show/when_resource_exists/does_not_output_to_stderr.yml
+++ b/spec/cassettes/brightbox_sql_snapshots/show/when_resource_exists/does_not_output_to_stderr.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://api.brightbox.dev/1.0/database_snapshots/dbi-12345?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_snapshots/dbi-12345?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Fri, 17 Jan 2014 10:45:59 GMT
 - request:
     method: post
-    uri: http://api.brightbox.dev/token
+    uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
       string: "{\"grant_type\":\"client_credentials\"}"

--- a/spec/commands/cloudips/update_spec.rb
+++ b/spec/commands/cloudips/update_spec.rb
@@ -10,7 +10,7 @@ describe "brightbox cloudips" do
     before do
       config_from_contents(USER_APP_CONFIG_CONTENTS)
 
-      stub_request(:post, "http://api.brightbox.dev/token").
+      stub_request(:post, "http://api.brightbox.localhost/token").
         to_return(status: 200, body: JSON.dump(access_token: "ACCESS-TOKEN", refresh_token: "REFRESH-TOKEN"))
     end
 
@@ -39,12 +39,12 @@ describe "brightbox cloudips" do
         let(:expected_args) { ["cip-12345", { :name => new_name }] }
 
         before do
-          stub_request(:put, "http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
             .with(:headers => { "Content-Type" => "application/json" },
                   :body => hash_including("name" => "New name"))
             .and_return(:status => 200, :body => json_response)
 
-          stub_request(:get, "http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
             .with(:headers => { "Content-Type" => "application/json" })
             .and_return(:status => 200, :body => json_response)
         end
@@ -62,12 +62,12 @@ describe "brightbox cloudips" do
         let(:expected_args) { ["cip-12345", { :name => "" }] }
 
         before do
-          stub_request(:put, "http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
             .with(:headers => { "Content-Type" => "application/json" },
                   :body => hash_including("name" => ""))
             .and_return(:status => 200, :body => json_response)
 
-          stub_request(:get, "http://api.brightbox.dev/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
             .with(:headers => { "Content-Type" => "application/json" })
             .and_return(:status => 200, :body => json_response)
         end

--- a/spec/commands/config/client_add_spec.rb
+++ b/spec/commands/config/client_add_spec.rb
@@ -9,7 +9,7 @@ describe "brightbox config" do
 
     let(:client_id) { "cli-12345" }
     let(:secret) { "qy6xxnvy4o0tgv5" }
-    let(:api_url) { "http://api.brightbox.dev" }
+    let(:api_url) { "http://api.brightbox.localhost" }
 
     let(:default_account) { "acc-12345" }
 

--- a/spec/commands/config/user_add_spec.rb
+++ b/spec/commands/config/user_add_spec.rb
@@ -15,7 +15,7 @@ describe "brightbox config" do
     let(:client_id) { "app-12345" }
     let(:secret) { "mocbuipbiaa6k6c" }
     let(:password) { "N:B3e%7Cmh" }
-    let(:api_url) { "http://api.brightbox.dev" }
+    let(:api_url) { "http://api.brightbox.localhost" }
 
     let(:default_account) { "acc-12345" }
     let(:client_alias) { email }

--- a/spec/commands/images/list_spec.rb
+++ b/spec/commands/images/list_spec.rb
@@ -10,7 +10,7 @@ describe "brightbox images" do
     before do
       config_from_contents(USER_APP_CONFIG_CONTENTS)
 
-      stub_request(:post, "http://api.brightbox.dev/token").
+      stub_request(:post, "http://api.brightbox.localhost/token").
         to_return(status: 200, body: JSON.dump(access_token: "ACCESS-TOKEN", refresh_token: "REFRESH-TOKEN"))
 
       image_listing_json = JSON.dump([
@@ -61,11 +61,11 @@ describe "brightbox images" do
         }
       ])
 
-      stub_request(:get, "http://api.brightbox.dev/1.0/images?account_id=acc-12345").
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345").
         with(headers: { "Authorization" => "Bearer ACCESS-TOKEN" }).
         to_return(status: 200, body: image_listing_json)
 
-      stub_request(:get, "http://api.brightbox.dev/1.0/account?account_id=acc-12345&nested=false").
+      stub_request(:get, "http://api.brightbox.localhost/1.0/account?account_id=acc-12345&nested=false").
         with(headers: { "Authorization" => "Bearer ACCESS-TOKEN" }).
         to_return(status: 200, body: JSON.dump({ id: "acc-12345" }))
     end

--- a/spec/commands/lbs/create_spec.rb
+++ b/spec/commands/lbs/create_spec.rb
@@ -34,7 +34,7 @@ describe "brightbox lbs" do
       end
 
       before do
-        stub_request(:post, "http://api.brightbox.dev/1.0/load_balancers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/load_balancers?account_id=acc-12345")
           .with(:body => hash_including("ssl_minimum_version" => "TLSv1.0"))
           .to_return(:status => 202, :body => json_response)
       end

--- a/spec/commands/lbs/update_spec.rb
+++ b/spec/commands/lbs/update_spec.rb
@@ -33,10 +33,10 @@ describe "brightbox lbs" do
       end
 
       before do
-        stub_request(:get, "http://api.brightbox.dev/1.0/load_balancers/lba-12345?account_id=acc-12345")
+        stub_request(:get, "http://api.brightbox.localhost/1.0/load_balancers/lba-12345?account_id=acc-12345")
           .to_return(:status => 200, :body => '{"id":"lba-12345"}')
 
-        stub_request(:put, "http://api.brightbox.dev/1.0/load_balancers/lba-12345?account_id=acc-12345")
+        stub_request(:put, "http://api.brightbox.localhost/1.0/load_balancers/lba-12345?account_id=acc-12345")
           .with(:body => hash_including("ssl_minimum_version" => "TLSv1.0"))
           .to_return(:status => 202, :body => json_response)
       end

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -9,7 +9,7 @@ describe "brightbox login" do
   let(:password) { "N:B3e%7Cmh" }
   let(:client_id) { "app-12345" }
   let(:secret) { "mocbuipbiaa6k6c" }
-  let(:api_url) { "http://api.brightbox.dev" }
+  let(:api_url) { "http://api.brightbox.localhost" }
 
   let(:default_account) { "acc-12345" }
   let(:client_alias) { email }

--- a/spec/commands/servers/create_spec.rb
+++ b/spec/commands/servers/create_spec.rb
@@ -15,7 +15,7 @@ describe "brightbox servers" do
       config = config_from_contents(USER_APP_CONFIG_CONTENTS)
       cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
 
-      stub_request(:post, "http://api.brightbox.dev/token").to_return(
+      stub_request(:post, "http://api.brightbox.localhost/token").to_return(
         :status => 200,
         :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}')
     end
@@ -37,7 +37,7 @@ describe "brightbox servers" do
       end
 
       it "requests nominated Cloud IP" do
-        stub_request(:post, "http://api.brightbox.dev/1.0/servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/servers?account_id=acc-12345")
           .with(:body => /"cloud_ip":"cip-12345"/)
           .and_return(:status => 202, :body => sample_response)
 
@@ -56,7 +56,7 @@ describe "brightbox servers" do
       end
 
       it "requests new allocated Cloud IP" do
-        stub_request(:post, "http://api.brightbox.dev/1.0/servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/servers?account_id=acc-12345")
           .with(:body => /"cloud_ip":"true"/)
           .and_return(:status => 202, :body => sample_response)
 
@@ -75,7 +75,7 @@ describe "brightbox servers" do
       end
 
       it "requests new server with encryption at rest enabled" do
-        stub_request(:post, "http://api.brightbox.dev/1.0/servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/servers?account_id=acc-12345")
           .with(:headers => { "Content-Type" => "application/json" },
                 :body => hash_including(:disk_encrypted => true))
           .and_return(:status => 202, :body => sample_response)

--- a/spec/commands/sql/instances/create_spec.rb
+++ b/spec/commands/sql/instances/create_spec.rb
@@ -71,11 +71,11 @@ describe "brightbox sql instances" do
       let(:expected_args) { { :maintenance_weekday => "5", :maintenance_hour => "11" } }
 
       before do
-        stub_request(:post, "http://api.brightbox.dev/token").to_return(
+        stub_request(:post, "http://api.brightbox.localhost/token").to_return(
           :status => 200,
           :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}')
 
-        stub_request(:post, "http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
           .with(:body => "{\"name\":null,\"description\":null,\"maintenance_weekday\":\"5\",\"maintenance_hour\":\"11\"}")
       end
 
@@ -90,11 +90,11 @@ describe "brightbox sql instances" do
       let(:expected_args) { { :maintenance_weekday => "4" } }
 
       before do
-        stub_request(:post, "http://api.brightbox.dev/token").to_return(
+        stub_request(:post, "http://api.brightbox.localhost/token").to_return(
           :status => 200,
           :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}')
 
-        stub_request(:post, "http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
           .with(:body => "{\"name\":null,\"description\":null,\"maintenance_weekday\":\"4\",\"maintenance_hour\":null}")
       end
 
@@ -117,7 +117,7 @@ describe "brightbox sql instances" do
       end
 
       before do
-        stub_request(:post, "http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
           .with(:headers => { "Content-Type" => "application/json" },
                 :body => hash_including("snapshot" => "dbi-1493j"))
           .and_return(:status => 202, :body => json_response)
@@ -145,7 +145,7 @@ describe "brightbox sql instances" do
       end
 
       before do
-        stub_request(:post, "http://api.brightbox.dev/1.0/database_servers?account_id=acc-12345")
+        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
           .and_return(:status => 202, :body => json_response)
       end
 

--- a/spec/commands/sql/instances/show_spec.rb
+++ b/spec/commands/sql/instances/show_spec.rb
@@ -18,7 +18,7 @@ describe "brghtbox sql instances" do
       end
 
       before do
-        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345").
+        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345").
           to_return(:status => 404, :body => json_response, :headers => { "Content-Type" => "" })
       end
 
@@ -61,7 +61,7 @@ describe "brghtbox sql instances" do
       end
 
       before do
-        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345").
+        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345").
           to_return(:status => 200, :body => json_response, :headers => { "Content-Type" => "" })
       end
 

--- a/spec/commands/sql/instances/update_spec.rb
+++ b/spec/commands/sql/instances/update_spec.rb
@@ -17,7 +17,7 @@ describe "brightbox sql instances" do
       let(:expected_args) { { :maintenance_weekday => "1" } }
 
       before do
-        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345")
+        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
           .to_return(:status => 200, :body => '{"id":"dbs-12345","maintenance_weekday":0, "maintenance_hour":6}')
           .to_return(:status => 200,
                      :body => '{
@@ -25,7 +25,7 @@ describe "brightbox sql instances" do
                        "maintenance_weekday":1,
                        "maintenance_hour":6}')
 
-        stub_request(:put, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345")
+        stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
           .with(:body => "{\"maintenance_weekday\":\"1\"}")
       end
 
@@ -41,11 +41,11 @@ describe "brightbox sql instances" do
       let(:expected_args) { { :snapshots_schedule => "0 12 * * 4" } }
 
       before do
-        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345")
+        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
 
-        stub_request(:put, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345")
+        stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
       end
 
@@ -64,11 +64,11 @@ describe "brightbox sql instances" do
       let(:expected_args) { { :snapshots_schedule => nil } }
 
       before do
-        stub_request(:get, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345")
+        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
 
-        stub_request(:put, "http://api.brightbox.dev/1.0/database_servers/dbs-12345?account_id=acc-12345")
+        stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
       end
 

--- a/spec/configs/api_client.ini
+++ b/spec/configs/api_client.ini
@@ -2,7 +2,7 @@
 default_client = testing
 
 [testing]
-api_url = http://api.brightbox.dev
+api_url = http://api.brightbox.localhost
 alias = testing
 client_id = cli-12345
 secret = qy6xxnvy4o0tgv5

--- a/spec/configs/user_app.ini
+++ b/spec/configs/user_app.ini
@@ -4,7 +4,7 @@ default_client = testing
 [testing]
 alias = testing
 username = jason.null@brightbox.com
-api_url = http://api.brightbox.dev
-auth_url = http://api.brightbox.dev
+api_url = http://api.brightbox.localhost
+auth_url = http://api.brightbox.localhost
 default_account = acc-12345
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,8 +33,8 @@ RSpec.configure do |config|
 
   config.before do
     # For each test, point to the testing endpoint to make it safer and easier to
-    # record from dev endpoints. Devs can DNS api.brightbox.dev to their dev service
-    stub_const("Brightbox::DEFAULT_API_ENDPOINT", ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev")
+    # record from dev endpoints. Devs can DNS api.brightbox.localhost to their dev service
+    stub_const("Brightbox::DEFAULT_API_ENDPOINT", ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.localhost")
     # And set a sane terminal size for Hirb
     ENV["COLUMNS"] = "120"
     ENV["LINES"] = "120"

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -18,7 +18,7 @@ VCR.configure do |vcr|
 
   vcr.before_record do |interaction|
     host = URI.parse(interaction.request.uri).host
-    interaction.request.uri.gsub!(host, "api.brightbox.dev")
+    interaction.request.uri.gsub!(host, "api.brightbox.localhost")
 
     # Sanitise identifiers as best as we can
     # We need the poser of Regexp so filter_sensitive doesn't help

--- a/spec/unit/brightbox/bb_config/add_login_spec.rb
+++ b/spec/unit/brightbox/bb_config/add_login_spec.rb
@@ -5,7 +5,7 @@ describe Brightbox::BBConfig, "#add_login" do
 
   let(:email) { "jason.null@brightbox.com" }
   let(:password) { "N:B3e%7Cmh" }
-  let(:api_url) { ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev" }
+  let(:api_url) { Brightbox::DEFAULT_API_ENDPOINT }
 
   context "when no config exists", vcr: true do
     let(:expected_config) do
@@ -78,7 +78,7 @@ EOS
   context "when configured with custom options", vcr: true do
     let(:original_config) { config_file_contents }
 
-    let(:custom_url) { ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev" }
+    let(:custom_url) { Brightbox::DEFAULT_API_ENDPOINT }
     let(:custom_app_id) { "app-23456" }
     let(:custom_app_secret) { "ho04hondtzjjdf4" }
     let(:custom_default_account) { "acc-23456" }
@@ -132,7 +132,7 @@ EOS
   context "when altering a custom option", vcr: true do
     let(:original_config) { config_file_contents }
 
-    let(:custom_url) { ENV["BRIGHTBOX_API_URL"] || "http://api.brightbox.dev" }
+    let(:custom_url) { Brightbox::DEFAULT_API_ENDPOINT }
     let(:custom_app_id) { "app-23456" }
     let(:custom_app_secret) { "ho04hondtzjjdf4" }
     let(:custom_default_account) { "acc-23456" }

--- a/spec/unit/brightbox/bb_config/add_section_spec.rb
+++ b/spec/unit/brightbox/bb_config/add_section_spec.rb
@@ -12,7 +12,7 @@ describe Brightbox::BBConfig do
       let(:options) do
         {
           :username => "jason.null@brightbox.com",
-          :api_url => "http://api.brightbox.dev"
+          :api_url => "http://api.brightbox.localhost"
         }
       end
       let(:saved_config) { config_file_contents }

--- a/spec/unit/brightbox/bb_config/find_or_set_default_account_spec.rb
+++ b/spec/unit/brightbox/bb_config/find_or_set_default_account_spec.rb
@@ -20,7 +20,7 @@ describe Brightbox::BBConfig do
       let(:contents) do
         <<-EOS
         [cli-default]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = cli-default
         secret = qy6xxnvy4o0tgv5
         default_account = acc-default
@@ -38,7 +38,7 @@ describe Brightbox::BBConfig do
       let(:contents) do
         <<-EOS
         [cli-12345]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = cli-12345
         secret = wrong_password
         EOS
@@ -64,7 +64,7 @@ describe Brightbox::BBConfig do
         [core]
         default_client = cli-12345
         [cli-12345]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = cli-12345
         secret = qy6xxnvy4o0tgv5
         EOS
@@ -81,7 +81,7 @@ describe Brightbox::BBConfig do
       let(:contents) do
         <<-EOS
         [app-12345]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = app-12345
         secret = mocbuipbiaa6k6c
         EOS

--- a/spec/unit/brightbox/bb_config/renew_tokens_spec.rb
+++ b/spec/unit/brightbox/bb_config/renew_tokens_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Brightbox::BBConfig do
-  let(:api_endpoint) { "http://api.brightbox.dev" }
+  let(:api_endpoint) { Brightbox::DEFAULT_API_ENDPOINT }
 
   # These are fake values that dev servers may choose to allow
   let(:username) { "jason.null@brightbox.com" }

--- a/spec/unit/brightbox/bb_config/to_fog_spec.rb
+++ b/spec/unit/brightbox/bb_config/to_fog_spec.rb
@@ -43,7 +43,7 @@ describe Brightbox::BBConfig do
 
       it "returns correct fog options" do
         expect(fog_config[:provider]).to eql("Brightbox")
-        expect(fog_config[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(fog_config[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
         expect(fog_config[:brightbox_client_id]).to eql("cli-12345")
         expect(fog_config[:brightbox_secret]).to eql("qy6xxnvy4o0tgv5")
       end
@@ -54,7 +54,7 @@ describe Brightbox::BBConfig do
 
       it "returns correct fog options" do
         expect(fog_config[:provider]).to eql("Brightbox")
-        expect(fog_config[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(fog_config[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
         expect(fog_config[:brightbox_client_id]).to eql("app-12345")
         expect(fog_config[:brightbox_secret]).to eql("mocbuipbiaa6k6c")
       end

--- a/spec/unit/brightbox/config/api_client/to_fog_spec.rb
+++ b/spec/unit/brightbox/config/api_client/to_fog_spec.rb
@@ -15,7 +15,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{secret}
         EOS
@@ -26,11 +26,11 @@ describe Brightbox::Config::ApiClient do
       end
 
       it "sets API endpoint correctly" do
-        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "copies API endpoint for auth endpoint correctly" do
-        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "sets client_id correctly" do
@@ -50,7 +50,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         auth_url = http://auth.dev.brightbox.com
         client_id = #{client_name}
         secret = #{secret}
@@ -58,7 +58,7 @@ describe Brightbox::Config::ApiClient do
       end
 
       it "sets API endpoint correctly" do
-        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "copies API endpoint for auth endpoint correctly" do
@@ -70,7 +70,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{secret}
         persistent = false
@@ -100,7 +100,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         secret = #{random_token}
         EOS
       end
@@ -114,7 +114,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         EOS
       end

--- a/spec/unit/brightbox/config/api_client/valid_spec.rb
+++ b/spec/unit/brightbox/config/api_client/valid_spec.rb
@@ -12,7 +12,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{random_token}
         EOS
@@ -27,7 +27,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{random_token}
         theme = blue
@@ -57,7 +57,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         secret = #{random_token}
         EOS
       end
@@ -71,7 +71,7 @@ describe Brightbox::Config::ApiClient do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         EOS
       end

--- a/spec/unit/brightbox/config/user_application/to_fog_spec.rb
+++ b/spec/unit/brightbox/config/user_application/to_fog_spec.rb
@@ -15,7 +15,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         username = user@example.com
         EOS
       end
@@ -25,11 +25,11 @@ describe Brightbox::Config::UserApplication do
       end
 
       it "sets API endpoint correctly" do
-        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "copies API endpoint for auth endpoint correctly" do
-        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "sets client_id correctly" do
@@ -49,7 +49,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{secret}
         username = user@example.com
@@ -61,11 +61,11 @@ describe Brightbox::Config::UserApplication do
       end
 
       it "sets API endpoint correctly" do
-        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "copies API endpoint for auth endpoint correctly" do
-        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_auth_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "sets client_id correctly" do
@@ -85,7 +85,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         auth_url = http://auth.dev.brightbox.com
         client_id = #{client_name}
         secret = #{secret}
@@ -94,7 +94,7 @@ describe Brightbox::Config::UserApplication do
       end
 
       it "sets API endpoint correctly" do
-        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.dev")
+        expect(for_fog[:brightbox_api_url]).to eql("http://api.brightbox.localhost")
       end
 
       it "copies API endpoint for auth endpoint correctly" do
@@ -106,7 +106,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{secret}
         username = user@example.com
@@ -138,7 +138,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{secret}
         EOS

--- a/spec/unit/brightbox/config/user_application/valid_spec.rb
+++ b/spec/unit/brightbox/config/user_application/valid_spec.rb
@@ -12,7 +12,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         username = user@example.com
         EOS
       end
@@ -26,7 +26,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{random_token}
         username = user@example.com
@@ -58,7 +58,7 @@ describe Brightbox::Config::UserApplication do
       let(:contents) do
         <<-EOS
         [#{client_name}]
-        api_url = http://api.brightbox.dev
+        api_url = http://api.brightbox.localhost
         client_id = #{client_name}
         secret = #{random_token}
         EOS


### PR DESCRIPTION
We have switched to using `.localhost` as a safe domain since `.dev` was
commercialised. This updates all existing references.