### PR TITLE
Update `gli` to v2.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Changes:
 * Remove post install message from gemspec
 * Updated `.dev` TLD used in testing to `.localhost` to avoid problems when the
   original was commercialised such as local DNS blocked by browsers.
+* Update `gli` to latest version v2.21.0 to clear some deprecations seen under
+  later Ruby versions
 
 ### v3.3.0 / 2021-09-17
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       dry-inflector (< 0.2)
       fog-brightbox (>= 1.3.0)
       fog-core (< 2.0)
-      gli (~> 2.12.0)
+      gli (~> 2.21.0)
       highline (~> 1.6.0)
       hirb (~> 0.6)
       i18n (>= 0.6, < 1.11)
@@ -37,7 +37,7 @@ GEM
       fog-core
       multi_json (~> 1.10)
     formatador (0.2.5)
-    gli (2.12.3)
+    gli (2.21.0)
     hashdiff (1.0.1)
     highline (1.6.21)
     hirb (0.7.3)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "fog-brightbox", ">= 1.3.0"
   s.add_dependency "fog-core", "< 2.0"
-  s.add_dependency "gli", "~> 2.12.0"
+  s.add_dependency "gli", "~> 2.21.0"
   s.add_dependency "i18n", ">= 0.6", "< 1.11"
   s.add_dependency "mime-types", "~> 2.6"
   s.add_dependency "multi_json", "~> 1.11.0"


### PR DESCRIPTION
This should include some deprecation fixes for later versions of Ruby
that are starting to appear in the command line.