### PR TITLE
Update `dry-inflector` as Ruby limit removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changes:
   original was commercialised such as local DNS blocked by browsers.
 * Update `gli` to latest version v2.21.0 to clear some deprecations seen under
   later Ruby versions
+* Remove pin for `dry-inflector` added to prevent issues with Ruby < 2.4
 
 ### v3.3.0 / 2021-09-17
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     brightbox-cli (4.0.0.rc1)
-      dry-inflector (< 0.2)
       fog-brightbox (>= 1.3.0)
       fog-core (< 2.0)
       gli (~> 2.21.0)
@@ -23,7 +22,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.4.3)
-    dry-inflector (0.1.2)
+    dry-inflector (0.2.0)
     excon (0.79.0)
     fog-brightbox (1.4.0)
       dry-inflector

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -28,9 +28,6 @@ Gem::Specification.new do |s|
   s.add_dependency "highline", "~> 1.6.0"
   s.add_dependency "hirb", "~> 0.6"
 
-  # dry-inflector >= 0.2 drops supports for Ruby < 2.4
-  s.add_dependency "dry-inflector", "< 0.2"
-
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-remote"
   s.add_development_dependency "rake"


### PR DESCRIPTION
`dry-inflector` had to be pinned to a version < 0.2 as Ruby 2.3 support
was dropped in a minor release. Now that is no longer a constraint, we
can remove the pin and update the gem.