### PR TITLE
Remove VCR identifier sanitisation

### DIFF
--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -19,14 +19,5 @@ VCR.configure do |vcr|
   vcr.before_record do |interaction|
     host = URI.parse(interaction.request.uri).host
     interaction.request.uri.gsub!(host, "api.brightbox.localhost")
-
-    # Sanitise identifiers as best as we can
-    # We need the poser of Regexp so filter_sensitive doesn't help
-    %w(acc col cip fwp fwr grp img lba srv typ usr zon).each do |prefix|
-      id_pattern = /#{prefix}-[0-9a-z]+/
-      interaction.request.uri.gsub!(id_pattern, "#{prefix}-12345")
-      interaction.request.body.gsub!(id_pattern, "#{prefix}-12345")
-      interaction.response.body.gsub!(id_pattern, "#{prefix}-12345")
-    end
   end
 end


### PR DESCRIPTION
This has the unfortunate side-effect of creating conflicting entries in
VCR recordings where one run could get a 201 response, then another
request for `srv-12345` gets a 404 and the later entry took precidence.

All the identifiers used in testing are from a development instance so
are not leaking real identifiers.

When all the VCR tests correctly setup and tear down resources and can
re-record then the re-use of 12345 will just cause problems.