### PR TITLE
Reduce testing timeout to 10 seconds

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,9 @@ USER_APP_CONFIG_CONTENTS = File.read(File.join(File.dirname(__FILE__), "configs/
 # Remember the $HOME of the test runner
 TEST_RUNNER_HOME = ENV["HOME"]
 
+# Reduce the default fog timeout
+Fog.timeout = 10
+
 RSpec.configure do |config|
   config.include CommonHelpers
   config.include ConfigHelpers


### PR DESCRIPTION
The default timeout for `fog` is 600 seconds so when an API call misses
a 10 minute wait is far too long. This cuts down to 10s which is just
enough to allow for replays and most requests.