### PR TITLE
Add `.gitattributes` to mark generated VCR files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+spec/cassettes/**/*.yml linguist-generated


### PR DESCRIPTION
A quality of life improvement to mark the VCR cassettes as generated on
GitHub to hopefully not overwhelm diffs with the changes when
re-recording.