### PR TITLE
Update `fog-brightbox` to `v1.5.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (4.0.0.rc1)
-      fog-brightbox (>= 1.3.0)
+      fog-brightbox (>= 1.5.0)
       fog-core (< 2.0)
       gli (~> 2.21.0)
       highline (~> 1.6.0)
@@ -23,8 +23,8 @@ GEM
       rexml
     diff-lcs (1.5.0)
     dry-inflector (0.2.0)
-    excon (0.79.0)
-    fog-brightbox (1.4.0)
+    excon (0.92.3)
+    fog-brightbox (1.5.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json
@@ -35,7 +35,7 @@ GEM
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    formatador (0.2.5)
+    formatador (0.3.0)
     gli (2.21.0)
     hashdiff (1.0.1)
     highline (1.6.21)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.3.0"
+  s.add_dependency "fog-brightbox", ">= 1.5.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21.0"
   s.add_dependency "i18n", ">= 0.6", "< 1.11"

--- a/spec/cassettes/Brightbox_Server/_destroy/when_server_exists/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_destroy/when_server_exists/should_work.yml
@@ -89,7 +89,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"image":"img-12345","name":"wow","server_type":"typ-12345"}'
+      string: '{"name":"wow","server_type":"typ-12345","image":"img-12345"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_show/when_server_exists/shows_detailed_attributes_of_a_server.yml
+++ b/spec/cassettes/Brightbox_Server/_show/when_server_exists/shows_detailed_attributes_of_a_server.yml
@@ -50,7 +50,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"image":"img-12345","name":"medium servers","server_type":"typ-12345"}'
+      string: '{"name":"medium servers","server_type":"typ-12345","image":"img-12345"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_shutdown/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_shutdown/should_work.yml
@@ -90,7 +90,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"image":"img-12345","name":"rspec_server_shutdown","server_type":"typ-12345"}'
+      string: '{"name":"rspec_server_shutdown","server_type":"typ-12345","image":"img-12345"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_start/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_start/should_work.yml
@@ -90,7 +90,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"image":"img-12345","name":"rspec_server_start","server_type":"typ-12345"}'
+      string: '{"name":"rspec_server_start","server_type":"typ-12345","image":"img-12345"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/Brightbox_Server/_stop/should_work.yml
+++ b/spec/cassettes/Brightbox_Server/_stop/should_work.yml
@@ -90,7 +90,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"image":"img-12345","name":"rspec_server_stop","server_type":"typ-12345"}'
+      string: '{"name":"rspec_server_stop","server_type":"typ-12345","image":"img-12345"}'
     headers:
       User-Agent:
       - fog/1.15.0

--- a/spec/cassettes/brightbox_sql_instances/create/--allow-access_srv-12345_grp-12345/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--allow-access_srv-12345_grp-12345/correctly_sends_API_parameters.yml
@@ -2,92 +2,1258 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"name\":null,\"description\":null,\"allow_access\":[\"srv-12345\",\"grp-12345\"],\"maintenance_weekday\":null,\"maintenance_hour\":null}"
+      string: '{"server_type":"2gb.nbs","image":"img-12345"}'
     headers:
       User-Agent:
-      - fog/1.20.0
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
       Authorization:
-      - OAuth f83da712e6299cda953513ec07f7a754f747d727
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
       Content-Type:
       - application/json
   response:
     status:
       code: 202
-      message:
+      message: Accepted
     headers:
-      Location:
-      - http://api.brightbox.localhost/1.0/database_servers/dbs-el0py
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:28 GMT
       Content-Type:
       - application/json; charset=utf-8
-      X-Ua-Compatible:
-      - IE=Edge
+      Content-Length:
+      - '2532'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/servers/srv-ant0d
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - 74a33404daa192a234ae9e050696b55a
+      - 10979ab6-1dfe-4875-a18f-8382c80d9cf2
       X-Runtime:
-      - '0.992636'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:02:30 GMT
-      Content-Length:
-      - '958'
-      Connection:
+      - '0.266268'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-12345","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-12345","name":"","status":"creating","locked":false,"hostname":"srv-12345","created_at":"2022-06-17T14:01:28.670Z","started_at":null,"deleted_at":null,"user_data":null,"fqdn":"srv-12345.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-12345","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-12345","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-12345"},"server_type":{"id":"typ-12345","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-12345","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-llq4t","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-llq4t","mac_address":"02:24:19:10:20:1a","ipv4_address":"10.16.32.26","ipv6_address":"2a02:1348:1dd:806:24:19ff:fe10:201a"}],"snapshots":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-12345.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-feoyj","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-feoyj","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-feoyj","size":40960,"source":"img-12345","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:01:28Z","updated_at":"2022-06-17T14:01:28Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:28 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
       - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2532'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"8f4fbd7851b742afadd56e60d94e6d79"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - dcdba4ef-0354-4cf3-b01a-9d401ee40fd5
+      X-Runtime:
+      - '0.054658'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-12345","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-12345","name":"","status":"creating","locked":false,"hostname":"srv-12345","created_at":"2022-06-17T14:01:28.000Z","started_at":null,"deleted_at":null,"user_data":null,"fqdn":"srv-12345.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-12345","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-12345","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-12345"},"server_type":{"id":"typ-12345","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-12345","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-llq4t","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-llq4t","mac_address":"02:24:19:10:20:1a","ipv4_address":"10.16.32.26","ipv6_address":"2a02:1348:1dd:806:24:19ff:fe10:201a"}],"snapshots":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-12345.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-feoyj","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-feoyj","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-feoyj","size":40960,"source":"img-12345","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:01:28Z","updated_at":"2022-06-17T14:01:28Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:28 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2552'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"a13c8a860adc6899ff8c5dc6e4706f1b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ae98c078-eda0-4b25-9fcc-eb827856cb36
+      X-Runtime:
+      - '0.055312'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-12345","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-12345","name":"","status":"active","locked":false,"hostname":"srv-12345","created_at":"2022-06-17T14:01:28.000Z","started_at":"2022-06-17T14:01:29.000Z","deleted_at":null,"user_data":null,"fqdn":"srv-12345.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-12345","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-12345","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-12345"},"server_type":{"id":"typ-12345","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-12345","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-llq4t","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-llq4t","mac_address":"02:24:19:10:20:1a","ipv4_address":"10.16.32.26","ipv6_address":"2a02:1348:1dd:806:24:19ff:fe10:201a"}],"snapshots":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-12345.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-feoyj","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-feoyj","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-feoyj","size":40960,"source":"img-12345","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:01:28Z","updated_at":"2022-06-17T14:01:28Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:29 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"id\":\"dbs-el0py\",\"resource_type\":\"database_server\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_servers/dbs-el0py\",\"name\":\"\",\"description\":\"\",\"admin_username\":\"admin\",\"admin_password\":\"7cykj0h2r0cnq1dt\",\"allow_access\":[\"srv-12345\",\"grp-12345\"],\"database_engine\":\"mysql\",\"database_version\":\"5.5\",\"status\":\"creating\",\"maintenance_weekday\":0,\"maintenance_hour\":6,\"created_at\":\"2014-02-19T17:02:29Z\",\"updated_at\":\"2014-02-19T17:02:29Z\",\"deleted_at\":null,\"account\":{\"id\":\"acc-12345\",\"resource_type\":\"account\",\"url\":\"https://api.gb1.brightbox.com/1.0/accounts/acc-12345\",\"name\":\"VCR
-        account\",\"status\":\"active\"},\"database_server_type\":{\"id\":\"dbt-12345\",\"resource_type\":\"database_type\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345\",\"name\":\"moxccmwwwhtn\",\"description\":\"\",\"disk_size\":8192,\"ram\":2048},\"cloud_ips\":[],\"zone\":{\"id\":\"zon-12345\",\"resource_type\":\"zone\",\"url\":\"https://api.gb1.brightbox.com/1.0/zones/zon-12345\",\"handle\":\"gb1-a\"}}"
+      string: '{"name":null,"description":null,"allow_access":["srv-12345","grp-12345"],"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1093'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-au9p6
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 837ee620-9452-4cec-bef5-fdd0f19dcfcd
+      X-Runtime:
+      - '0.603211'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9p6","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9p6","name":"","description":"","admin_username":"admin","admin_password":"gag6itqwqdr1ef5o","allow_access":["srv-12345","grp-12345"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:01:30Z","updated_at":"2022-06-17T14:01:30Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
     http_version:
-  recorded_at: Wed, 19 Feb 2014 17:02:30 GMT
+  recorded_at: Fri, 17 Jun 2022 14:01:30 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/servers/srv-12345?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2554'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - dcf8a8ca-b043-4647-bbd4-fb5decc7a410
+      X-Runtime:
+      - '0.127301'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-12345","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-12345","name":"","status":"deleting","locked":false,"hostname":"srv-12345","created_at":"2022-06-17T14:01:28.000Z","started_at":"2022-06-17T14:01:29.000Z","deleted_at":null,"user_data":null,"fqdn":"srv-12345.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-12345","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-12345","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-12345"},"server_type":{"id":"typ-12345","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-12345","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-llq4t","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-llq4t","mac_address":"02:24:19:10:20:1a","ipv4_address":"10.16.32.26","ipv6_address":"2a02:1348:1dd:806:24:19ff:fe10:201a"}],"snapshots":[],"server_groups":[{"id":"grp-12345","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-12345","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-12345.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-feoyj","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-feoyj","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-feoyj","size":40960,"source":"img-12345","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:01:28Z","updated_at":"2022-06-17T14:01:28Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:30 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9p6?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1079'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"ca241bc39587768a898b933647cdfd23"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 6d01321b-17fd-4853-a13a-76792476da59
+      X-Runtime:
+      - '0.055292'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9p6","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9p6","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["srv-12345","grp-12345"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:01:30Z","updated_at":"2022-06-17T14:01:30Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:30 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9p6?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1079'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"ca241bc39587768a898b933647cdfd23"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 07b476a9-75fb-4c72-b3c5-0a992c03a491
+      X-Runtime:
+      - '0.046696'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9p6","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9p6","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["srv-12345","grp-12345"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:01:30Z","updated_at":"2022-06-17T14:01:30Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:30 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9p6?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:31 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1079'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"ca241bc39587768a898b933647cdfd23"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8e9f75fe-e07d-40c8-8713-7988ee8bc7be
+      X-Runtime:
+      - '0.062839'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9p6","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9p6","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["srv-12345","grp-12345"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:01:30Z","updated_at":"2022-06-17T14:01:30Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:31 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9p6?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:34 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1065'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"a11c208ddbeb713fe7b97d6626dd3edc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f5c5cc76-63ff-4667-808f-aacc506befc7
+      X-Runtime:
+      - '0.046715'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9p6","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9p6","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["grp-12345"],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:01:30Z","updated_at":"2022-06-17T14:01:32Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:34 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9p6?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer a0d19b44a714561825e03cb0337c56f7cd2a6149
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:01:34 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1067'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - e20bbb9e-64cf-486d-8633-cf10b8d593a3
+      X-Runtime:
+      - '0.140721'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9p6","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9p6","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["grp-12345"],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:01:30Z","updated_at":"2022-06-17T14:01:34Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:01:34 GMT
 - request:
     method: post
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"client_credentials\"}"
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
-      - fog/1.20.0
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
       Authorization:
-      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
       Content-Type:
       - application/json
   response:
     status:
-      code: 400
-      message:
+      code: 200
+      message: OK
     headers:
-      X-Frame-Options:
-      - sameorigin
-      X-Xss-Protection:
-      - 1; mode=block
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:13 GMT
       Content-Type:
-      - application/json;charset=utf-8
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
       Cache-Control:
       - no-store
-      Content-Length:
-      - '135'
-      X-Ua-Compatible:
-      - IE=Edge
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"0ece98b4de1cdaacc30f35e7015ee206"
       X-Request-Id:
-      - 893f534ed3cfb55a8af6e992a717eda2
+      - da171e4d-2f98-4f66-981f-fc7ed1150938
       X-Runtime:
-      - '0.104069'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:28:09 GMT
-      Connection:
-      - close
+      - '0.090067'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"f71229779b71874a8b9823707413a806de616ee2","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:13 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"error\":\"unauthorized_client\",\"error_description\":\"The authenticated
-        client is not authorized to use the access grant type provided.\"}"
+      string: '{"server_type":"2gb.nbs","image":"img-linux"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2533'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/servers/srv-hktd0
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - f78ed0af-8ded-4e14-a0b3-ca05426db05a
+      X-Runtime:
+      - '0.283298'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-hktd0","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-hktd0","name":"","status":"creating","locked":false,"hostname":"srv-hktd0","created_at":"2022-06-17T14:03:13.811Z","started_at":null,"deleted_at":null,"user_data":null,"fqdn":"srv-hktd0.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-linux","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-linux","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-systm"},"server_type":{"id":"typ-mq9s8","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-mq9s8","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-i1yjt","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-i1yjt","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-fdkzj","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-fdkzj","mac_address":"02:24:19:11:18:16","ipv4_address":"10.17.24.22","ipv6_address":"2a02:1348:1dd:4605:24:19ff:fe11:1816"}],"snapshots":[],"server_groups":[{"id":"grp-wla7a","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-wla7a","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-wla7a.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-ll1s3","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-ll1s3","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-ll1s3","size":40960,"source":"img-linux","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:03:13Z","updated_at":"2022-06-17T14:03:13Z","deleted_at":null}]}'
     http_version:
-  recorded_at: Wed, 19 Feb 2014 17:28:09 GMT
+  recorded_at: Fri, 17 Jun 2022 14:03:13 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/servers/srv-hktd0?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2533'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"cd6920e924442c000342e39bcf39ee34"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 1b240b7c-4c0e-4abb-93ad-137865481c9a
+      X-Runtime:
+      - '0.055919'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-hktd0","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-hktd0","name":"","status":"creating","locked":false,"hostname":"srv-hktd0","created_at":"2022-06-17T14:03:13.000Z","started_at":null,"deleted_at":null,"user_data":null,"fqdn":"srv-hktd0.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-linux","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-linux","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-systm"},"server_type":{"id":"typ-mq9s8","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-mq9s8","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-i1yjt","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-i1yjt","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-fdkzj","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-fdkzj","mac_address":"02:24:19:11:18:16","ipv4_address":"10.17.24.22","ipv6_address":"2a02:1348:1dd:4605:24:19ff:fe11:1816"}],"snapshots":[],"server_groups":[{"id":"grp-wla7a","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-wla7a","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-wla7a.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-ll1s3","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-ll1s3","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-ll1s3","size":40960,"source":"img-linux","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:03:13Z","updated_at":"2022-06-17T14:03:13Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:14 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/servers/srv-hktd0?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2553'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"b7d92b75d3297995558aba735407e781"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ba1057ec-4b36-4015-b648-dd2c71f4d73b
+      X-Runtime:
+      - '0.055384'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-hktd0","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-hktd0","name":"","status":"active","locked":false,"hostname":"srv-hktd0","created_at":"2022-06-17T14:03:13.000Z","started_at":"2022-06-17T14:03:14.000Z","deleted_at":null,"user_data":null,"fqdn":"srv-hktd0.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-linux","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-linux","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-systm"},"server_type":{"id":"typ-mq9s8","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-mq9s8","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-i1yjt","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-i1yjt","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-fdkzj","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-fdkzj","mac_address":"02:24:19:11:18:16","ipv4_address":"10.17.24.22","ipv6_address":"2a02:1348:1dd:4605:24:19ff:fe11:1816"}],"snapshots":[],"server_groups":[{"id":"grp-wla7a","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-wla7a","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-wla7a.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-ll1s3","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-ll1s3","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-ll1s3","size":40960,"source":"img-linux","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:03:13Z","updated_at":"2022-06-17T14:03:13Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:15 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/server_groups?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4351'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"3633f0056afb7611ae934287e92722b5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 3d634b04-43d9-4c02-ad97-85b3aa9e00e9
+      X-Runtime:
+      - '0.035070'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '[{"id":"grp-wla7a","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-wla7a","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-wla7a.honcho.brightbox.localhost","account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"firewall_policy":{"id":"fwp-cqggo","resource_type":"firewall_policy","url":"https://api.brightbox.localhost/1.0/firewall_policies/fwp-cqggo","default":true,"name":"default","created_at":"2022-06-17T12:00:23.000Z","description":"Applied
+        to the default server group."},"servers":[{"id":"srv-nyta5","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-nyta5","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-nyta5","fqdn":"srv-nyta5.honcho.brightbox.localhost","created_at":"2022-06-17T13:38:15.000Z","started_at":"2022-06-17T13:38:16.000Z","deleted_at":null},{"id":"srv-9dur3","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-9dur3","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-9dur3","fqdn":"srv-9dur3.honcho.brightbox.localhost","created_at":"2022-06-17T13:39:03.000Z","started_at":"2022-06-17T13:39:04.000Z","deleted_at":null},{"id":"srv-1vyrl","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-1vyrl","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-1vyrl","fqdn":"srv-1vyrl.honcho.brightbox.localhost","created_at":"2022-06-17T13:39:24.000Z","started_at":"2022-06-17T13:39:25.000Z","deleted_at":null},{"id":"srv-oukzl","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-oukzl","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-oukzl","fqdn":"srv-oukzl.honcho.brightbox.localhost","created_at":"2022-06-17T13:40:45.000Z","started_at":"2022-06-17T13:40:46.000Z","deleted_at":null},{"id":"srv-hzpin","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-hzpin","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-hzpin","fqdn":"srv-hzpin.honcho.brightbox.localhost","created_at":"2022-06-17T13:40:47.000Z","started_at":"2022-06-17T13:40:48.000Z","deleted_at":null},{"id":"srv-v4a6h","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-v4a6h","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-v4a6h","fqdn":"srv-v4a6h.honcho.brightbox.localhost","created_at":"2022-06-17T13:41:46.000Z","started_at":"2022-06-17T13:41:47.000Z","deleted_at":null},{"id":"srv-vkb53","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-vkb53","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-vkb53","fqdn":"srv-vkb53.honcho.brightbox.localhost","created_at":"2022-06-17T13:41:53.000Z","started_at":"2022-06-17T13:41:54.000Z","deleted_at":null},{"id":"srv-qpgjr","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-qpgjr","name":"medium
+        servers","status":"active","locked":false,"hostname":"srv-qpgjr","fqdn":"srv-qpgjr.honcho.brightbox.localhost","created_at":"2022-06-17T13:42:10.000Z","started_at":"2022-06-17T13:42:11.000Z","deleted_at":null},{"id":"srv-vnti5","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-vnti5","name":"","status":"active","locked":false,"hostname":"srv-vnti5","fqdn":"srv-vnti5.honcho.brightbox.localhost","created_at":"2022-06-17T13:47:03.000Z","started_at":"2022-06-17T13:47:04.000Z","deleted_at":null},{"id":"srv-pnv1x","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-pnv1x","name":"","status":"active","locked":false,"hostname":"srv-pnv1x","fqdn":"srv-pnv1x.honcho.brightbox.localhost","created_at":"2022-06-17T13:55:46.000Z","started_at":"2022-06-17T13:55:47.000Z","deleted_at":null},{"id":"srv-hktd0","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-hktd0","name":"","status":"active","locked":false,"hostname":"srv-hktd0","fqdn":"srv-hktd0.honcho.brightbox.localhost","created_at":"2022-06-17T14:03:13.000Z","started_at":"2022-06-17T14:03:14.000Z","deleted_at":null}]}]'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:15 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"allow_access":["srv-hktd0","grp-wla7a"],"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1093'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-jvdga
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 81f99eb0-e1ec-4c6f-bf99-cde2e23a3d35
+      X-Runtime:
+      - '0.632855'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-jvdga","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-jvdga","name":"","description":"","admin_username":"admin","admin_password":"5k1bso4axg3z3w64","allow_access":["srv-hktd0","grp-wla7a"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:03:15Z","updated_at":"2022-06-17T14:03:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-fiwa8","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-fiwa8","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:15 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/servers/srv-hktd0?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '2555'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - e24b2c62-4748-4eed-87c9-92897fd6d5b5
+      X-Runtime:
+      - '0.147327'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"srv-hktd0","resource_type":"server","url":"https://api.brightbox.localhost/1.0/servers/srv-hktd0","name":"","status":"deleting","locked":false,"hostname":"srv-hktd0","created_at":"2022-06-17T14:03:13.000Z","started_at":"2022-06-17T14:03:14.000Z","deleted_at":null,"user_data":null,"fqdn":"srv-hktd0.honcho.brightbox.localhost","compatibility_mode":false,"console_url":null,"console_token":null,"console_token_expires":null,"disk_encrypted":false,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"snapshots_retention":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"image":{"id":"img-linux","resource_type":"image","url":"https://api.brightbox.localhost/1.0/images/img-linux","name":"ubuntu-xenial-16.04-amd64-server","username":null,"status":"available","locked":false,"description":"","source":"linux.img","source_trigger":"manual","arch":"x86_64","created_at":"2022-06-17T12:00:22.000Z","official":true,"public":true,"owner":"acc-systm"},"server_type":{"id":"typ-mq9s8","resource_type":"server_type","url":"https://api.brightbox.localhost/1.0/server_types/typ-mq9s8","name":"2GB
+        Block Storage","status":"available","cores":2,"ram":2048,"disk_size":0,"handle":"2gb.nbs","storage_type":"network"},"zone":{"id":"zon-i1yjt","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-i1yjt","handle":"honcho-b"},"cloud_ips":[],"interfaces":[{"id":"int-fdkzj","resource_type":"interface","url":"https://api.brightbox.localhost/1.0/interfaces/int-fdkzj","mac_address":"02:24:19:11:18:16","ipv4_address":"10.17.24.22","ipv6_address":"2a02:1348:1dd:4605:24:19ff:fe11:1816"}],"snapshots":[],"server_groups":[{"id":"grp-wla7a","resource_type":"server_group","url":"https://api.brightbox.localhost/1.0/server_groups/grp-wla7a","name":"default","description":"All
+        new servers are added to this group unless specified otherwise.","created_at":"2022-06-17T12:00:23.000Z","default":true,"fqdn":"grp-wla7a.honcho.brightbox.localhost"}],"volumes":[{"id":"vol-ll1s3","resource_type":"volume","url":"https://api.brightbox.localhost/1.0/volumes/vol-ll1s3","name":null,"description":null,"boot":true,"delete_with_server":true,"encrypted":false,"filesystem_label":null,"filesystem_type":null,"locked":false,"serial":"vol-ll1s3","size":40960,"source":"img-linux","source_type":"image","status":"attached","storage_type":"network","created_at":"2022-06-17T14:03:13Z","updated_at":"2022-06-17T14:03:13Z","deleted_at":null}]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:15 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-jvdga?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1079'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"de19271cf6b51be2fa651b867fb2851a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 36de02fc-825e-49e9-8838-e1418aa3a0a7
+      X-Runtime:
+      - '0.047551'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-jvdga","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-jvdga","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["srv-hktd0","grp-wla7a"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:03:15Z","updated_at":"2022-06-17T14:03:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-fiwa8","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-fiwa8","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-jvdga?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1079'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"de19271cf6b51be2fa651b867fb2851a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fc8df828-e8e0-4998-9cfd-a4edb735c105
+      X-Runtime:
+      - '0.045839'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-jvdga","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-jvdga","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["srv-hktd0","grp-wla7a"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:03:15Z","updated_at":"2022-06-17T14:03:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-fiwa8","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-fiwa8","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-jvdga?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1079'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"de19271cf6b51be2fa651b867fb2851a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 2efec224-75ac-4656-8fa5-07db3e7520db
+      X-Runtime:
+      - '0.045494'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-jvdga","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-jvdga","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["srv-hktd0","grp-wla7a"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:03:15Z","updated_at":"2022-06-17T14:03:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-fiwa8","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-fiwa8","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:17 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-jvdga?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1065'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"ab4782415cfecc0d3a925496946a5811"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f1679ea7-159c-425f-ad13-fe1cb15fd343
+      X-Runtime:
+      - '0.053736'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-jvdga","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-jvdga","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["grp-wla7a"],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:03:15Z","updated_at":"2022-06-17T14:03:17Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-fiwa8","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-fiwa8","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:19 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-jvdga?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer f71229779b71874a8b9823707413a806de616ee2
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 14:03:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1067'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - e86bcfdc-e2a8-439e-b1ec-66f40753d1bc
+      X-Runtime:
+      - '0.143770'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-jvdga","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-jvdga","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["grp-wla7a"],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T14:03:15Z","updated_at":"2022-06-17T14:03:19Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-fiwa8","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-fiwa8","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 14:03:19 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--engine_mysql/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--engine_mysql/correctly_sends_API_parameters.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null,\"engine\":\"mysql\"}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"engine":"mysql"}'
     headers:
       User-Agent:
       - fog/1.20.0
@@ -40,54 +40,624 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "{\"id\":\"dbs-pb9ag\",\"resource_type\":\"database_server\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_servers/dbs-pb9ag\",\"name\":\"\",\"description\":\"\",\"admin_username\":\"admin\",\"admin_password\":\"dr2dj6y53n67gc1r\",\"allow_access\":[],\"database_engine\":\"mysql\",\"database_version\":\"5.5\",\"status\":\"creating\",\"maintenance_weekday\":0,\"maintenance_hour\":6,\"created_at\":\"2014-02-19T17:04:29Z\",\"updated_at\":\"2014-02-19T17:04:29Z\",\"deleted_at\":null,\"account\":{\"id\":\"acc-12345\",\"resource_type\":\"account\",\"url\":\"https://api.gb1.brightbox.com/1.0/accounts/acc-12345\",\"name\":\"VCR
-        account\",\"status\":\"active\"},\"database_server_type\":{\"id\":\"dbt-12345\",\"resource_type\":\"database_type\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345\",\"name\":\"moxccmwwwhtn\",\"description\":\"\",\"disk_size\":8192,\"ram\":2048},\"cloud_ips\":[],\"zone\":{\"id\":\"zon-12345\",\"resource_type\":\"zone\",\"url\":\"https://api.gb1.brightbox.com/1.0/zones/zon-12345\",\"handle\":\"gb1-a\"}}"
+      string: '{"id":"dbs-pb9ag","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-pb9ag","name":"","description":"","admin_username":"admin","admin_password":"dr2dj6y53n67gc1r","allow_access":[],"database_engine":"mysql","database_version":"5.5","status":"creating","maintenance_weekday":0,"maintenance_hour":6,"created_at":"2014-02-19T17:04:29Z","updated_at":"2014-02-19T17:04:29Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"VCR
+        account","status":"active"},"database_server_type":{"id":"dbt-12345","resource_type":"database_type","url":"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345","name":"moxccmwwwhtn","description":"","disk_size":8192,"ram":2048},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"}}'
     http_version:
   recorded_at: Wed, 19 Feb 2014 17:04:30 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-d0ead?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"f6c99f75ff8b71b6e100f272274023d6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 95a33974-de09-4837-87e7-68df7ebcd14b
+      X-Runtime:
+      - '0.046384'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-d0ead","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-d0ead","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:11Z","updated_at":"2022-06-17T12:16:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:12 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-d0ead?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"f6c99f75ff8b71b6e100f272274023d6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f336d494-ccdf-4556-a6c5-90f60933c20a
+      X-Runtime:
+      - '0.046994'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-d0ead","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-d0ead","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:11Z","updated_at":"2022-06-17T12:16:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:12 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-d0ead?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"f6c99f75ff8b71b6e100f272274023d6"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 15a897ac-04fa-49b4-a40e-7079ce0ca93f
+      X-Runtime:
+      - '0.054843'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-d0ead","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-d0ead","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:11Z","updated_at":"2022-06-17T12:16:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:13 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-d0ead?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"ca11a8dba4685899f7e5cb29de2980cc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 81b90af0-9916-44c1-9ded-c6f5b60b0cae
+      X-Runtime:
+      - '0.054817'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-d0ead","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-d0ead","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:11Z","updated_at":"2022-06-17T12:16:13Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:15 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-d0ead?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 3aae70d8-b836-44b3-9c4f-8926835c7e2d
+      X-Runtime:
+      - '0.156627'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-d0ead","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-d0ead","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:11Z","updated_at":"2022-06-17T12:16:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:15 GMT
 - request:
     method: post
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"client_credentials\"}"
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
-      - fog/1.20.0
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
       Authorization:
-      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
       Content-Type:
       - application/json
   response:
     status:
-      code: 400
-      message:
+      code: 200
+      message: OK
     headers:
-      X-Frame-Options:
-      - sameorigin
-      X-Xss-Protection:
-      - 1; mode=block
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 13:46:03 GMT
       Content-Type:
-      - application/json;charset=utf-8
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
       Cache-Control:
       - no-store
-      Content-Length:
-      - '135'
-      X-Ua-Compatible:
-      - IE=Edge
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"833e90a67557ef9b2f61adc67d1cb2ac"
       X-Request-Id:
-      - 775cfad846fd60d83ce69ca527177e87
+      - fb788208-dac8-4ba3-b02d-ae4eb77eccf0
       X-Runtime:
-      - '0.149038'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:28:10 GMT
-      Connection:
-      - close
+      - '0.088478'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"7ec98598641798ad05b00044ede0574834d848e3","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 13:46:03 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"error\":\"unauthorized_client\",\"error_description\":\"The authenticated
-        client is not authorized to use the access grant type provided.\"}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null,"engine":"mysql"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 7ec98598641798ad05b00044ede0574834d848e3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 13:46:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1070'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 3d68a085-cc8b-494b-afbc-5e998f3988ab
+      X-Runtime:
+      - '0.307682'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-2n6xv","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv","name":"","description":"","admin_username":"admin","admin_password":"07uxizw5y0ce9zhu","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T13:46:04Z","updated_at":"2022-06-17T13:46:04Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
     http_version:
-  recorded_at: Wed, 19 Feb 2014 17:28:10 GMT
+  recorded_at: Fri, 17 Jun 2022 13:46:04 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 7ec98598641798ad05b00044ede0574834d848e3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 13:46:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"86b6874df6511890d50a7ec74fffe0db"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - '008fd1d2-abc4-4c7e-a117-4af7ce137d3e'
+      X-Runtime:
+      - '0.048515'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-2n6xv","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T13:46:04Z","updated_at":"2022-06-17T13:46:04Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 13:46:04 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 7ec98598641798ad05b00044ede0574834d848e3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 13:46:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"86b6874df6511890d50a7ec74fffe0db"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e794e723-f415-4627-96c3-5cb57fa60056
+      X-Runtime:
+      - '0.050662'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-2n6xv","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T13:46:04Z","updated_at":"2022-06-17T13:46:04Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 13:46:04 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 7ec98598641798ad05b00044ede0574834d848e3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 13:46:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"a33adc46e5f82e26df1f52ee167dd572"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f33f1bc0-6ec2-42a1-b2f5-e2277f2b8ca4
+      X-Runtime:
+      - '0.047069'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-2n6xv","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T13:46:04Z","updated_at":"2022-06-17T13:46:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 13:46:05 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 7ec98598641798ad05b00044ede0574834d848e3
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 13:46:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - e9098a6c-bad4-4e97-a7a8-ca5e975c4dfc
+      X-Runtime:
+      - '0.154557'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-2n6xv","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2n6xv","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T13:46:04Z","updated_at":"2022-06-17T13:46:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 13:46:05 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--engine_mysql_--engine-version_5_6/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--engine_mysql_--engine-version_5_6/correctly_sends_API_parameters.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null,\"engine\":\"mysql\",\"version\":\"5.6\"}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"engine":"mysql","version":"5.6"}'
     headers:
       User-Agent:
       - fog/1.20.0
@@ -40,8 +40,8 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "{\"id\":\"dbs-kh13c\",\"resource_type\":\"database_server\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_servers/dbs-kh13c\",\"name\":\"\",\"description\":\"\",\"admin_username\":\"admin\",\"admin_password\":\"57th4lk8dfe8ukbn\",\"allow_access\":[],\"database_engine\":\"mysql\",\"database_version\":\"5.6\",\"status\":\"creating\",\"maintenance_weekday\":0,\"maintenance_hour\":6,\"created_at\":\"2014-02-19T17:08:22Z\",\"updated_at\":\"2014-02-19T17:08:22Z\",\"deleted_at\":null,\"account\":{\"id\":\"acc-12345\",\"resource_type\":\"account\",\"url\":\"https://api.gb1.brightbox.com/1.0/accounts/acc-12345\",\"name\":\"VCR
-        account\",\"status\":\"active\"},\"database_server_type\":{\"id\":\"dbt-12345\",\"resource_type\":\"database_type\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345\",\"name\":\"nhwtnmetpimc\",\"description\":\"\",\"disk_size\":6144,\"ram\":2048},\"cloud_ips\":[],\"zone\":{\"id\":\"zon-12345\",\"resource_type\":\"zone\",\"url\":\"https://api.gb1.brightbox.com/1.0/zones/zon-12345\",\"handle\":\"gb1-a\"}}"
+      string: '{"id":"dbs-kh13c","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-kh13c","name":"","description":"","admin_username":"admin","admin_password":"57th4lk8dfe8ukbn","allow_access":[],"database_engine":"mysql","database_version":"5.6","status":"creating","maintenance_weekday":0,"maintenance_hour":6,"created_at":"2014-02-19T17:08:22Z","updated_at":"2014-02-19T17:08:22Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"VCR
+        account","status":"active"},"database_server_type":{"id":"dbt-12345","resource_type":"database_type","url":"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345","name":"nhwtnmetpimc","description":"","disk_size":6144,"ram":2048},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"}}'
     http_version:
   recorded_at: Wed, 19 Feb 2014 17:08:29 GMT
 - request:
@@ -49,7 +49,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"client_credentials\"}"
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
       - fog/1.20.0
@@ -86,8 +86,62 @@ http_interactions:
       - close
     body:
       encoding: UTF-8
-      string: "{\"error\":\"unauthorized_client\",\"error_description\":\"The authenticated
-        client is not authorized to use the access grant type provided.\"}"
+      string: '{"error":"unauthorized_client","error_description":"The authenticated
+        client is not authorized to use the access grant type provided."}'
     http_version:
   recorded_at: Wed, 19 Feb 2014 17:28:10 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null,"engine":"mysql","version":"5.6"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 188f4867e982968f790c86d870b8db22be7dcd44
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 422
+      message: Unprocessable Entity
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 11:54:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '116'
+      Connection:
+      - keep-alive
+      Status:
+      - 422 Unprocessable Entity
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 47699a81-3df0-43a1-a99b-18e540fd06b4
+      X-Runtime:
+      - '0.036210'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error_name":"unprocessable_entity","errors":["MySQL version 5.6 is
+        no longer supported. Specify a newer version"]}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 11:54:03 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--engine_mysql_--engine-version_8_0/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--engine_mysql_--engine-version_8_0/correctly_sends_API_parameters.yml
@@ -1,0 +1,393 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:15 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"b7c324f59038df1f4e074e09ce8bc3c7"
+      X-Request-Id:
+      - 2384e44c-0969-4296-98c3-58eae8e7d91d
+      X-Runtime:
+      - '0.102222'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"e61cfc9aae6b4736ffaf14286b2f5875a7a1b9f4","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:15 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null,"engine":"mysql","version":"8.0"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1070'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-y92bg
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - d8dad665-9559-4589-ac33-7dde378a7f56
+      X-Runtime:
+      - '0.311048'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-y92bg","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-y92bg","name":"","description":"","admin_username":"admin","admin_password":"vu2ohfx8vgq3hmrt","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:15Z","updated_at":"2022-06-17T12:16:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-y92bg?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"5a300b6368a71a053b7cff76e1b40d54"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - aab86c43-3fc1-4994-94db-8fb0ebc86fbf
+      X-Runtime:
+      - '0.046296'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-y92bg","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-y92bg","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:15Z","updated_at":"2022-06-17T12:16:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-y92bg?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"5a300b6368a71a053b7cff76e1b40d54"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 56a8ef7c-42fe-4739-8281-bf3a4fc54d3d
+      X-Runtime:
+      - '0.045546'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-y92bg","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-y92bg","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:15Z","updated_at":"2022-06-17T12:16:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:16 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-y92bg?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"5a300b6368a71a053b7cff76e1b40d54"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cedaccf7-f3a1-4f6d-b784-938fb026976a
+      X-Runtime:
+      - '0.045813'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-y92bg","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-y92bg","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:15Z","updated_at":"2022-06-17T12:16:15Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:17 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-y92bg?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"5f4c1d08a8d39dc97f1de4e14d5c63cb"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 74003b51-fe5b-4dd0-8546-7267bda31964
+      X-Runtime:
+      - '0.052322'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-y92bg","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-y92bg","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:15Z","updated_at":"2022-06-17T12:16:17Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:19 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-y92bg?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 16297dc8-9583-438d-a94b-6cdef6d8db97
+      X-Runtime:
+      - '0.177597'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-y92bg","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-y92bg","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:15Z","updated_at":"2022-06-17T12:16:19Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:19 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--maintenance-weekday_5_--maintenance_hour_11/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--maintenance-weekday_5_--maintenance_hour_11/correctly_sends_API_parameters.yml
@@ -1,0 +1,393 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:19 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"761c9dec7e64bd402fa64986c8c2a31e"
+      X-Request-Id:
+      - 3eae0b3f-941c-497b-ab78-1f7dbbc60b8f
+      X-Runtime:
+      - '0.090669'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"5b23d5651b6ff17b98691a2c7bc9be020a45e8e4","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:19 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"maintenance_weekday":"5","maintenance_hour":"11","snapshots_schedule":null}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1071'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-au9iz
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 6ec75a30-62e1-477f-a5f4-413cd176af80
+      X-Runtime:
+      - '0.348161'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9iz","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9iz","name":"","description":"","admin_username":"admin","admin_password":"hukigjxwhusk6w76","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":5,"maintenance_hour":11,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:19Z","updated_at":"2022-06-17T12:16:19Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:19 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9iz?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:19 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1057'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"f6ad630fe7ed3a7d10f8b031c0657c5a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 304e43b7-b892-4942-a72f-2fee09e3a20d
+      X-Runtime:
+      - '0.061868'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9iz","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9iz","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":5,"maintenance_hour":11,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:19Z","updated_at":"2022-06-17T12:16:19Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:19 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9iz?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1057'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"f6ad630fe7ed3a7d10f8b031c0657c5a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 59f209ce-e9c1-4a0d-8106-d0aa54fb140e
+      X-Runtime:
+      - '0.051357'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9iz","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9iz","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":5,"maintenance_hour":11,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:19Z","updated_at":"2022-06-17T12:16:19Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:20 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9iz?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:21 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1057'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"f6ad630fe7ed3a7d10f8b031c0657c5a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4e887cf5-8354-4673-a9b4-c0883a7cb265
+      X-Runtime:
+      - '0.047691'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9iz","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9iz","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":5,"maintenance_hour":11,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:19Z","updated_at":"2022-06-17T12:16:19Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:21 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9iz?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1055'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"55a88c6068b60a20879a7fb1fb3d2435"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 119368b7-20fd-4731-acf0-70d052633043
+      X-Runtime:
+      - '0.048261'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9iz","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9iz","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":5,"maintenance_hour":11,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:19Z","updated_at":"2022-06-17T12:16:21Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:23 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-au9iz?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1057'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - fbdb4db9-f241-4fec-954f-5106ab14eb44
+      X-Runtime:
+      - '0.157863'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-au9iz","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-au9iz","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":5,"maintenance_hour":11,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:19Z","updated_at":"2022-06-17T12:16:23Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:23 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--maintenance-weekday_thursday/correctly_sends_API_parameters.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--maintenance-weekday_thursday/correctly_sends_API_parameters.yml
@@ -2,50 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
-    body:
-      encoding: UTF-8
-      string: '{"name":null,"description":null,"allow_access":["10.0.0.0"],"maintenance_weekday":null,"maintenance_hour":null}'
-    headers:
-      User-Agent:
-      - fog/1.20.0
-      Authorization:
-      - OAuth f83da712e6299cda953513ec07f7a754f747d727
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message:
-    headers:
-      Location:
-      - http://api.brightbox.localhost/1.0/database_servers/dbs-w5r2e
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Ua-Compatible:
-      - IE=Edge
-      Cache-Control:
-      - no-cache
-      X-Request-Id:
-      - bf3532acbb8d3092843846faf4dd4606
-      X-Runtime:
-      - '1.045299'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:02:16 GMT
-      Content-Length:
-      - '945'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: UTF-8
-      string: '{"id":"dbs-w5r2e","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w5r2e","name":"","description":"","admin_username":"admin","admin_password":"g2edl7v5jcordqxv","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.5","status":"creating","maintenance_weekday":0,"maintenance_hour":6,"created_at":"2014-02-19T17:02:14Z","updated_at":"2014-02-19T17:02:14Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"VCR
-        account","status":"active"},"database_server_type":{"id":"dbt-12345","resource_type":"database_type","url":"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345","name":"moxccmwwwhtn","description":"","disk_size":8192,"ram":2048},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"}}'
-    http_version:
-  recorded_at: Wed, 19 Feb 2014 17:02:16 GMT
-- request:
-    method: post
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
@@ -67,7 +23,7 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:23 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -83,23 +39,23 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Etag:
-      - W/"80e9800f5524b1d16afcf9e15b92abd0"
+      - W/"0b89fad340010c6131d8655268205951"
       X-Request-Id:
-      - a303259c-6995-4905-91dc-4f91facbfb27
+      - 140c05b4-f085-404e-8232-e30b811104b4
       X-Runtime:
-      - '0.088840'
+      - '0.087725'
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"4eaa0ac481f53ebcd2aa431db1f7ad87c7b359f9","token_type":"Bearer","scope":"infrastructure,
+      string: '{"access_token":"d4dfedafa18458e8257fe0957c3540a07c2dd64f","token_type":"Bearer","scope":"infrastructure,
         orbit","expires_in":7199}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:23 GMT
 - request:
     method: post
     uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"name":null,"description":null,"allow_access":["10.0.0.0"],"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+      string: '{"name":null,"description":null,"maintenance_weekday":"4","maintenance_hour":null,"snapshots_schedule":null}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -117,11 +73,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1080'
+      - '1070'
       Connection:
       - keep-alive
       Status:
@@ -135,25 +91,25 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Location:
-      - http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-rc642
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ae6d7c0f-8010-454b-8c31-ff3626eb8e13
+      - cd02ab05-efff-472f-8b8d-6592eb13c73c
       X-Runtime:
-      - '0.493642'
+      - '0.371938'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":"9uklmdzblxr0x0j8","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-rc642","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rc642","name":"","description":"","admin_username":"admin","admin_password":"kzxnh5h5j5n01dww","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":4,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:23Z","updated_at":"2022-06-17T12:16:23Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:23 GMT
 - request:
     method: get
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-rc642?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -174,11 +130,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1066'
+      - '1056'
       Connection:
       - keep-alive
       Status:
@@ -192,25 +148,25 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Etag:
-      - W/"0d07374b91bae44beffc1903258a4860"
+      - W/"8e0205ba4c32f70746f1637f9c6978e6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a5c21c9f-ff65-4fb7-bd32-1bc815107763
+      - 6548aff8-844f-4e7f-8f1d-a0a6d7e05e7c
       X-Runtime:
-      - '0.051527'
+      - '0.056850'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-rc642","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rc642","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":4,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:23Z","updated_at":"2022-06-17T12:16:23Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:23 GMT
 - request:
     method: get
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-rc642?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -231,11 +187,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1066'
+      - '1056'
       Connection:
       - keep-alive
       Status:
@@ -249,25 +205,25 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Etag:
-      - W/"0d07374b91bae44beffc1903258a4860"
+      - W/"8e0205ba4c32f70746f1637f9c6978e6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0d00e9a5-83b3-45bb-942e-5e21f250db45
+      - 23d63083-accb-435f-b496-78adf401d25e
       X-Runtime:
-      - '0.049919'
+      - '0.049032'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-rc642","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rc642","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":4,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:23Z","updated_at":"2022-06-17T12:16:23Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:23 GMT
 - request:
     method: get
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-rc642?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -288,11 +244,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:11 GMT
+      - Fri, 17 Jun 2022 12:16:25 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1064'
+      - '1056'
       Connection:
       - keep-alive
       Status:
@@ -306,25 +262,82 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Etag:
-      - W/"7d834ef57d6c8d78cf6dfd77f644fc62"
+      - W/"8e0205ba4c32f70746f1637f9c6978e6"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 72412b81-4da2-4680-89c1-03da24d86acf
+      - 69059f48-dad3-4f3b-a85f-c6434b1293ed
       X-Runtime:
-      - '0.056234'
+      - '0.052484'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:10Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-rc642","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rc642","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":4,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:23Z","updated_at":"2022-06-17T12:16:23Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:11 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:25 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-rc642?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"9118b7fa7009def5b47a6cdba941c389"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fd0b7fc3-b01d-4b13-8041-d61c9dd899fe
+      X-Runtime:
+      - '0.058101'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-rc642","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rc642","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":4,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:23Z","updated_at":"2022-06-17T12:16:25Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:27 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-rc642?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -345,11 +358,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:11 GMT
+      - Fri, 17 Jun 2022 12:16:27 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1066'
+      - '1056'
       Connection:
       - keep-alive
       Status:
@@ -365,16 +378,16 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - bacc0764-a532-4d3f-9749-bc2f1a41956c
+      - db49b258-739c-4b08-a6c9-969610b28f63
       X-Runtime:
-      - '0.163195'
+      - '0.155095'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-rc642","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rc642","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":4,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:23Z","updated_at":"2022-06-17T12:16:27Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:11 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:27 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--snapshot_dbi-12345/includes_schedule_fields_in_response.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--snapshot_dbi-12345/includes_schedule_fields_in_response.yml
@@ -1,0 +1,1466 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-16ru8?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"05edfa051d00bc8549814723f615b70b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - aebeff81-89b9-4ac5-ae61-8cf869898f6f
+      X-Runtime:
+      - '0.051807'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-16ru8","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-16ru8","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:52Z","updated_at":"2022-06-17T12:43:52Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:52 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-16ru8?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"4ac3b2b38e64f4c47ff730645648b7f7"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9c3515d1-10f7-46d0-8912-6697cdf73f18
+      X-Runtime:
+      - '0.053783'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-16ru8","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-16ru8","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:52Z","updated_at":"2022-06-17T12:43:53Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:53 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-16ru8/snapshot
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Link:
+      - "<https://api.brightbox.localhost/1.0/database_snapshots/dbi-fcxmv>; rel=snapshot"
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 9567b192-b920-4472-9d75-dc6965848656
+      X-Runtime:
+      - '0.135074'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-16ru8","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-16ru8","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:52Z","updated_at":"2022-06-17T12:43:53Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:53 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_snapshots/dbi-fcxmv?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '570'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"635de30f0cceb32090324f2f1ba873fc"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 82405128-8997-4d18-89d6-37dcf8433a79
+      X-Runtime:
+      - '0.041296'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbi-fcxmv","resource_type":"database_snapshot","url":"https://api.brightbox.localhost/1.0/database_snapshots/dbi-fcxmv","name":"Snapshot
+        of dbs-16ru8","description":"","status":"available","locked":false,"database_engine":"mysql","database_version":"8.0","source":"dbs-16ru8","source_trigger":"manual","size":0,"created_at":"2022-06-17T12:43:53Z","updated_at":"2022-06-17T12:43:53Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:53 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-16ru8?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - a01097e2-88cc-4937-af4c-2bf0fd8b9bff
+      X-Runtime:
+      - '0.150674'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-16ru8","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-16ru8","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:52Z","updated_at":"2022-06-17T12:43:53Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:53 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_snapshots/dbi-fcxmv?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '569'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - ccaba4fe-73bc-4e14-a768-7acd7c5ee15d
+      X-Runtime:
+      - '0.086318'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbi-fcxmv","resource_type":"database_snapshot","url":"https://api.brightbox.localhost/1.0/database_snapshots/dbi-fcxmv","name":"Snapshot
+        of dbs-16ru8","description":"","status":"deleting","locked":false,"database_engine":"mysql","database_version":"8.0","source":"dbs-16ru8","source_trigger":"manual","size":0,"created_at":"2022-06-17T12:43:53Z","updated_at":"2022-06-17T12:43:53Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:54 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null,"snapshot":"dbi-fcxmv"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-21kls
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 581e83dc-8db9-417a-8064-6c7823535d26
+      X-Runtime:
+      - '0.309248'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-21kls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-21kls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:54Z","updated_at":"2022-06-17T12:43:54Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:54 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-21kls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"62dbb8a2c0674a903498b0963a1ef777"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 90b0ee9c-90f6-4b2a-b8ab-de26c9c86056
+      X-Runtime:
+      - '0.051513'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-21kls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-21kls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:54Z","updated_at":"2022-06-17T12:43:54Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:54 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-21kls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"62dbb8a2c0674a903498b0963a1ef777"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 40fd9a5e-605b-4e01-b60d-50f6772722ed
+      X-Runtime:
+      - '0.051261'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-21kls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-21kls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:54Z","updated_at":"2022-06-17T12:43:54Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:54 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-21kls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"62dbb8a2c0674a903498b0963a1ef777"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 10871838-d245-45f5-9e2e-14f31571fea1
+      X-Runtime:
+      - '0.051492'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-21kls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-21kls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:54Z","updated_at":"2022-06-17T12:43:54Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:55 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-21kls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"0b475dfeb40f41c65e204f743cf78504"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - fa7bdb8b-a61f-4503-9ee9-953d4ddca6e1
+      X-Runtime:
+      - '0.043110'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-21kls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-21kls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:54Z","updated_at":"2022-06-17T12:43:55Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:57 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-21kls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer cc23ede8f3c54d340cf06772242659fa9fa1b826
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:43:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - ea2dca19-ed62-4d15-81b2-431d22c794ef
+      X-Runtime:
+      - '0.145820'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-21kls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-21kls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:43:54Z","updated_at":"2022-06-17T12:43:57Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:43:57 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/token
+    body:
+      encoding: UTF-8
+      string: '{"grant_type":"client_credentials"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:10 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      Cache-Control:
+      - no-store
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"a6d66dfa57a4a2e58689420a62a526c5"
+      X-Request-Id:
+      - a359320d-e56f-4e55-90da-68b3bd53c1dd
+      X-Runtime:
+      - '0.086379'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:10 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1070'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-inim5
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - c09b9966-5853-41eb-ad6f-f7d6c34b283e
+      X-Runtime:
+      - '0.340933'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-inim5","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-inim5","name":"","description":"","admin_username":"admin","admin_password":"fb1k202pmoepvw7e","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:10Z","updated_at":"2022-06-17T12:44:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:11 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-inim5?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"b08bd4799412feb32d7a3fbb66cb4162"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 8435abac-1106-4c68-a2d2-71e432d4bd4b
+      X-Runtime:
+      - '0.052057'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-inim5","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-inim5","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:10Z","updated_at":"2022-06-17T12:44:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:11 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-inim5?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"7e36a7aa1299725167fd44e02cb6e6ff"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - e4981269-4e57-410f-a62b-efb83990ed12
+      X-Runtime:
+      - '0.043517'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-inim5","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-inim5","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:10Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:12 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-inim5/snapshot
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Link:
+      - "<https://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce>; rel=snapshot"
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - fa847eec-8bea-4daa-b0f7-9425042e6f94
+      X-Runtime:
+      - '0.125689'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-inim5","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-inim5","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:10Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:12 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '570'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"9530803848f13cd7039cf7ee355009c4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bb9d8e50-2fcb-4009-98a0-a2bd27280d06
+      X-Runtime:
+      - '0.045634'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbi-tv2ce","resource_type":"database_snapshot","url":"https://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce","name":"Snapshot
+        of dbs-inim5","description":"","status":"available","locked":false,"database_engine":"mysql","database_version":"8.0","source":"dbs-inim5","source_trigger":"manual","size":0,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:12 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '570'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"9530803848f13cd7039cf7ee355009c4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 115223f8-8dd5-4dd6-bd1b-c02d286ead45
+      X-Runtime:
+      - '0.048592'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbi-tv2ce","resource_type":"database_snapshot","url":"https://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce","name":"Snapshot
+        of dbs-inim5","description":"","status":"available","locked":false,"database_engine":"mysql","database_version":"8.0","source":"dbs-inim5","source_trigger":"manual","size":0,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:12 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
+    body:
+      encoding: UTF-8
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null,"snapshot":"dbi-tv2ce"}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-95ucf
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 0b27a0c1-5438-49d5-b35e-c06e63a1adf3
+      X-Runtime:
+      - '0.332797'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-95ucf","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-95ucf","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:12 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-95ucf?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"d6bf3e6a63e84208a6a9d092b2e701ca"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - f1f20edb-772f-4e65-a4c4-e87ada816c0c
+      X-Runtime:
+      - '0.059896'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-95ucf","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-95ucf","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:13 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-inim5?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - bc97a4ba-2f0b-4aba-b47c-d2a641d84c9b
+      X-Runtime:
+      - '0.165156'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-inim5","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-inim5","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:10Z","updated_at":"2022-06-17T12:44:13Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:13 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '569'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 9acd26b2-c0c7-4b70-82e7-fa32e900aafd
+      X-Runtime:
+      - '0.101209'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbi-tv2ce","resource_type":"database_snapshot","url":"https://api.brightbox.localhost/1.0/database_snapshots/dbi-tv2ce","name":"Snapshot
+        of dbs-inim5","description":"","status":"deleting","locked":false,"database_engine":"mysql","database_version":"8.0","source":"dbs-inim5","source_trigger":"manual","size":0,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:13Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:13 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-95ucf?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"d6bf3e6a63e84208a6a9d092b2e701ca"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bcde7274-c179-4433-9e38-2246b35988ea
+      X-Runtime:
+      - '0.053161'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-95ucf","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-95ucf","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:12Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:13 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-95ucf?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"78c04facdeed0b701f3f2c7cee5272b4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - ec98ede9-76a8-44fa-b512-a30b93d7e11e
+      X-Runtime:
+      - '0.050812'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-95ucf","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-95ucf","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:14Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:14 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-95ucf?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 133fc1759354ee7b058a2ddbd7dc7fa3d7d49a50
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:44:14 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - fa464089-5e76-494e-97f3-51145e7d80ba
+      X-Runtime:
+      - '0.177695'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-95ucf","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-95ucf","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:44:12Z","updated_at":"2022-06-17T12:44:14Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:44:14 GMT
+recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/--snapshots-schedule_0_12_4_/includes_schedule_fields_in_response.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/--snapshots-schedule_0_12_4_/includes_schedule_fields_in_response.yml
@@ -2,50 +2,6 @@
 http_interactions:
 - request:
     method: post
-    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
-    body:
-      encoding: UTF-8
-      string: '{"name":null,"description":null,"allow_access":["10.0.0.0"],"maintenance_weekday":null,"maintenance_hour":null}'
-    headers:
-      User-Agent:
-      - fog/1.20.0
-      Authorization:
-      - OAuth f83da712e6299cda953513ec07f7a754f747d727
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 202
-      message:
-    headers:
-      Location:
-      - http://api.brightbox.localhost/1.0/database_servers/dbs-w5r2e
-      Content-Type:
-      - application/json; charset=utf-8
-      X-Ua-Compatible:
-      - IE=Edge
-      Cache-Control:
-      - no-cache
-      X-Request-Id:
-      - bf3532acbb8d3092843846faf4dd4606
-      X-Runtime:
-      - '1.045299'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:02:16 GMT
-      Content-Length:
-      - '945'
-      Connection:
-      - Keep-Alive
-    body:
-      encoding: UTF-8
-      string: '{"id":"dbs-w5r2e","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-w5r2e","name":"","description":"","admin_username":"admin","admin_password":"g2edl7v5jcordqxv","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"5.5","status":"creating","maintenance_weekday":0,"maintenance_hour":6,"created_at":"2014-02-19T17:02:14Z","updated_at":"2014-02-19T17:02:14Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"VCR
-        account","status":"active"},"database_server_type":{"id":"dbt-12345","resource_type":"database_type","url":"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345","name":"moxccmwwwhtn","description":"","disk_size":8192,"ram":2048},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"}}'
-    http_version:
-  recorded_at: Wed, 19 Feb 2014 17:02:16 GMT
-- request:
-    method: post
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
@@ -67,7 +23,7 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:27 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -83,23 +39,24 @@ http_interactions:
       X-Content-Type-Options:
       - nosniff
       Etag:
-      - W/"80e9800f5524b1d16afcf9e15b92abd0"
+      - W/"8d2f02c25a571faf1ad212e2259b4b37"
       X-Request-Id:
-      - a303259c-6995-4905-91dc-4f91facbfb27
+      - 61c42eaf-0c7f-4032-b2e5-0eb32d975c84
       X-Runtime:
-      - '0.088840'
+      - '0.086178'
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"4eaa0ac481f53ebcd2aa431db1f7ad87c7b359f9","token_type":"Bearer","scope":"infrastructure,
+      string: '{"access_token":"57a19f851d7ce54da83b07aebc5529b5096ddfaa","token_type":"Bearer","scope":"infrastructure,
         orbit","expires_in":7199}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:27 GMT
 - request:
     method: post
     uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: '{"name":null,"description":null,"allow_access":["10.0.0.0"],"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":"0
+        12 * * 4"}'
     headers:
       User-Agent:
       - fog-core/1.45.0
@@ -117,11 +74,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:27 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1080'
+      - '1096'
       Connection:
       - keep-alive
       Status:
@@ -135,25 +92,26 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Location:
-      - http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - ae6d7c0f-8010-454b-8c31-ff3626eb8e13
+      - 2baec1dd-ba90-4b83-a208-86041af8ea70
       X-Runtime:
-      - '0.493642'
+      - '0.349348'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":"9uklmdzblxr0x0j8","allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-v0o0c","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c","name":"","description":"","admin_username":"admin","admin_password":"7esnotr81631924k","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":"0
+        12 * * 4","snapshots_schedule_next_at":"2022-06-23T12:00:00Z","created_at":"2022-06-17T12:16:27Z","updated_at":"2022-06-17T12:16:27Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:27 GMT
 - request:
     method: get
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -174,11 +132,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:27 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1066'
+      - '1082'
       Connection:
       - keep-alive
       Status:
@@ -192,25 +150,26 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Etag:
-      - W/"0d07374b91bae44beffc1903258a4860"
+      - W/"524c2fc081d0ddd28c99fb3bd2e72c4b"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - a5c21c9f-ff65-4fb7-bd32-1bc815107763
+      - cf57eeec-ee6b-44d8-98d2-42be7b188779
       X-Runtime:
-      - '0.051527'
+      - '0.056046'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-v0o0c","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":"0
+        12 * * 4","snapshots_schedule_next_at":"2022-06-23T12:00:00Z","created_at":"2022-06-17T12:16:27Z","updated_at":"2022-06-17T12:16:27Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:27 GMT
 - request:
     method: get
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -231,11 +190,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:09 GMT
+      - Fri, 17 Jun 2022 12:16:28 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1066'
+      - '1082'
       Connection:
       - keep-alive
       Status:
@@ -249,25 +208,26 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Etag:
-      - W/"0d07374b91bae44beffc1903258a4860"
+      - W/"524c2fc081d0ddd28c99fb3bd2e72c4b"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 0d00e9a5-83b3-45bb-942e-5e21f250db45
+      - b6a7c4ea-3c5c-4c4e-a78c-2baee20d0d49
       X-Runtime:
-      - '0.049919'
+      - '0.048148'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-v0o0c","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":"0
+        12 * * 4","snapshots_schedule_next_at":"2022-06-23T12:00:00Z","created_at":"2022-06-17T12:16:27Z","updated_at":"2022-06-17T12:16:27Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:28 GMT
 - request:
     method: get
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -288,11 +248,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:11 GMT
+      - Fri, 17 Jun 2022 12:16:29 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1064'
+      - '1080'
       Connection:
       - keep-alive
       Status:
@@ -306,25 +266,26 @@ http_interactions:
       X-Oauth-Scopes:
       - infrastructure, orbit
       Etag:
-      - W/"7d834ef57d6c8d78cf6dfd77f644fc62"
+      - W/"0a71dd547d40bb2bb71a17fb4702057c"
       Cache-Control:
       - max-age=0, private, must-revalidate
       X-Request-Id:
-      - 72412b81-4da2-4680-89c1-03da24d86acf
+      - 3f23cb63-9242-4cdb-ab32-3f4f8983e814
       X-Runtime:
-      - '0.056234'
+      - '0.046270'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:10Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-v0o0c","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":"0
+        12 * * 4","snapshots_schedule_next_at":"2022-06-23T12:00:00Z","created_at":"2022-06-17T12:16:27Z","updated_at":"2022-06-17T12:16:29Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:11 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:29 GMT
 - request:
     method: delete
-    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-2yrux?account_id=acc-12345
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c?account_id=acc-12345
     body:
       encoding: US-ASCII
       string: ''
@@ -345,11 +306,11 @@ http_interactions:
       Server:
       - nginx/1.18.0
       Date:
-      - Fri, 17 Jun 2022 12:16:11 GMT
+      - Fri, 17 Jun 2022 12:16:29 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '1066'
+      - '1082'
       Connection:
       - keep-alive
       Status:
@@ -365,16 +326,17 @@ http_interactions:
       Cache-Control:
       - no-cache
       X-Request-Id:
-      - bacc0764-a532-4d3f-9749-bc2f1a41956c
+      - dea4e5fc-fd2b-4e6e-9947-7c13f7f1070c
       X-Runtime:
-      - '0.163195'
+      - '0.163464'
       Vary:
       - Origin
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"dbs-2yrux","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-2yrux","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":["10.0.0.0"],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:09Z","updated_at":"2022-06-17T12:16:11Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+      string: '{"id":"dbs-v0o0c","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-v0o0c","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":"0
+        12 * * 4","snapshots_schedule_next_at":"2022-06-23T12:00:00Z","created_at":"2022-06-17T12:16:27Z","updated_at":"2022-06-17T12:16:29Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
         test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
         DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Fri, 17 Jun 2022 12:16:11 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:29 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_password.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_password.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null}'
     headers:
       User-Agent:
       - fog/1.20.0
@@ -40,54 +40,569 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "{\"id\":\"dbs-28vhw\",\"resource_type\":\"database_server\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_servers/dbs-28vhw\",\"name\":\"\",\"description\":\"\",\"admin_username\":\"admin\",\"admin_password\":\"477wwwj48yifrnuk\",\"allow_access\":[],\"database_engine\":\"mysql\",\"database_version\":\"5.5\",\"status\":\"creating\",\"maintenance_weekday\":0,\"maintenance_hour\":6,\"created_at\":\"2014-02-19T17:01:31Z\",\"updated_at\":\"2014-02-19T17:01:31Z\",\"deleted_at\":null,\"account\":{\"id\":\"acc-12345\",\"resource_type\":\"account\",\"url\":\"https://api.gb1.brightbox.com/1.0/accounts/acc-12345\",\"name\":\"VCR
-        account\",\"status\":\"active\"},\"database_server_type\":{\"id\":\"dbt-12345\",\"resource_type\":\"database_type\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345\",\"name\":\"moxccmwwwhtn\",\"description\":\"\",\"disk_size\":8192,\"ram\":2048},\"cloud_ips\":[],\"zone\":{\"id\":\"zon-12345\",\"resource_type\":\"zone\",\"url\":\"https://api.gb1.brightbox.com/1.0/zones/zon-12345\",\"handle\":\"gb1-a\"}}"
+      string: '{"id":"dbs-28vhw","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-28vhw","name":"","description":"","admin_username":"admin","admin_password":"477wwwj48yifrnuk","allow_access":[],"database_engine":"mysql","database_version":"5.5","status":"creating","maintenance_weekday":0,"maintenance_hour":6,"created_at":"2014-02-19T17:01:31Z","updated_at":"2014-02-19T17:01:31Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"VCR
+        account","status":"active"},"database_server_type":{"id":"dbt-12345","resource_type":"database_type","url":"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345","name":"moxccmwwwhtn","description":"","disk_size":8192,"ram":2048},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"}}'
     http_version:
   recorded_at: Wed, 19 Feb 2014 17:01:33 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-ifjcd?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 97758c306f49321310fa27d88f9d7b84973ab853
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:01:43 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"7543fb7b5a2505e16302d097731e91a5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5654e4d2-3911-47af-88c6-64322f959f58
+      X-Runtime:
+      - '0.050640'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-ifjcd","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-ifjcd","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:01:43Z","updated_at":"2022-06-17T12:01:43Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:01:43 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-q34pn?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 3cbabf1fbb28640e375330a3088159228258fa6b
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:03:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"075852bd8156e9d96a2a083d8f7e50e1"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 4882625c-b190-4038-8c75-92299c54d263
+      X-Runtime:
+      - '0.052174'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-q34pn","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-q34pn","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:03:38Z","updated_at":"2022-06-17T12:03:39Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:03:39 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-rdfjy?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 76414b5916ba5e98f31ad7dd27d201ebe9f7da49
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:04:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"debe07ad7be85933f20181b4a6323e70"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 73e3fe61-ac91-43cd-a810-b02d8ad6fb9e
+      X-Runtime:
+      - '0.053153'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-rdfjy","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-rdfjy","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:04:02Z","updated_at":"2022-06-17T12:04:02Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:04:02 GMT
 - request:
     method: post
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"client_credentials\"}"
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
-      - fog/1.20.0
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
       Authorization:
-      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
       Content-Type:
       - application/json
   response:
     status:
-      code: 400
-      message:
+      code: 200
+      message: OK
     headers:
-      X-Frame-Options:
-      - sameorigin
-      X-Xss-Protection:
-      - 1; mode=block
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:05 GMT
       Content-Type:
-      - application/json;charset=utf-8
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
       Cache-Control:
       - no-store
-      Content-Length:
-      - '135'
-      X-Ua-Compatible:
-      - IE=Edge
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"a2df81a7bcae9105c2eb40aad9901b29"
       X-Request-Id:
-      - e3b686ff75ce866c5d2bee654a1612e4
+      - b06cee11-f478-49b1-b965-c6234c6c16cf
       X-Runtime:
-      - '0.114259'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:28:09 GMT
-      Connection:
-      - close
+      - '0.090943'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"f3f06893024f3e66f08837b93a0c8f9fe2d0b42f","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:05 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"error\":\"unauthorized_client\",\"error_description\":\"The authenticated
-        client is not authorized to use the access grant type provided.\"}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1070'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 280ccdc3-cd69-4b9c-a2bb-8470ad648c16
+      X-Runtime:
+      - '0.333162'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9p9ls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls","name":"","description":"","admin_username":"admin","admin_password":"fm489u3e2nfwnt2s","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:05Z","updated_at":"2022-06-17T12:16:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
     http_version:
-  recorded_at: Wed, 19 Feb 2014 17:28:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:05 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"808e1ccdbdc3459053362ebc28b2988e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 90965e71-649e-4147-8446-edeb432981bf
+      X-Runtime:
+      - '0.051816'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9p9ls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:05Z","updated_at":"2022-06-17T12:16:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:05 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"808e1ccdbdc3459053362ebc28b2988e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - dd774733-5c31-4cc2-b11c-c08a7bb45e7e
+      X-Runtime:
+      - '0.058420'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9p9ls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:05Z","updated_at":"2022-06-17T12:16:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:05 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"808e1ccdbdc3459053362ebc28b2988e"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - cd5196b7-d0eb-4a82-9015-fa2a5f7e1ebb
+      X-Runtime:
+      - '0.053665'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9p9ls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:05Z","updated_at":"2022-06-17T12:16:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:07 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"bb4054ad918384c6418bc6f5e0fa8f02"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - bf579c2f-dab8-49b9-b77a-ebd9cf222790
+      X-Runtime:
+      - '0.045518'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9p9ls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:05Z","updated_at":"2022-06-17T12:16:07Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:09 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 3da671c6-2466-4fa1-9f2a-cd0578b2a442
+      X-Runtime:
+      - '0.148666'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9p9ls","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9p9ls","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:05Z","updated_at":"2022-06-17T12:16:09Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:09 GMT
 recorded_with: VCR 2.5.0

--- a/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_username.yml
+++ b/spec/cassettes/brightbox_sql_instances/create/without_arguments/reports_the_new_admin_username.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"name\":null,\"description\":null,\"maintenance_weekday\":null,\"maintenance_hour\":null}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null}'
     headers:
       User-Agent:
       - fog/1.20.0
@@ -40,54 +40,512 @@ http_interactions:
       - Keep-Alive
     body:
       encoding: UTF-8
-      string: "{\"id\":\"dbs-rqxs1\",\"resource_type\":\"database_server\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rqxs1\",\"name\":\"\",\"description\":\"\",\"admin_username\":\"admin\",\"admin_password\":\"g4wwmcd2yphryc5o\",\"allow_access\":[],\"database_engine\":\"mysql\",\"database_version\":\"5.5\",\"status\":\"creating\",\"maintenance_weekday\":0,\"maintenance_hour\":6,\"created_at\":\"2014-02-19T17:01:21Z\",\"updated_at\":\"2014-02-19T17:01:21Z\",\"deleted_at\":null,\"account\":{\"id\":\"acc-12345\",\"resource_type\":\"account\",\"url\":\"https://api.gb1.brightbox.com/1.0/accounts/acc-12345\",\"name\":\"VCR
-        account\",\"status\":\"active\"},\"database_server_type\":{\"id\":\"dbt-12345\",\"resource_type\":\"database_type\",\"url\":\"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345\",\"name\":\"moxccmwwwhtn\",\"description\":\"\",\"disk_size\":8192,\"ram\":2048},\"cloud_ips\":[],\"zone\":{\"id\":\"zon-12345\",\"resource_type\":\"zone\",\"url\":\"https://api.gb1.brightbox.com/1.0/zones/zon-12345\",\"handle\":\"gb1-a\"}}"
+      string: '{"id":"dbs-rqxs1","resource_type":"database_server","url":"https://api.gb1.brightbox.com/1.0/database_servers/dbs-rqxs1","name":"","description":"","admin_username":"admin","admin_password":"g4wwmcd2yphryc5o","allow_access":[],"database_engine":"mysql","database_version":"5.5","status":"creating","maintenance_weekday":0,"maintenance_hour":6,"created_at":"2014-02-19T17:01:21Z","updated_at":"2014-02-19T17:01:21Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.gb1.brightbox.com/1.0/accounts/acc-12345","name":"VCR
+        account","status":"active"},"database_server_type":{"id":"dbt-12345","resource_type":"database_type","url":"https://api.gb1.brightbox.com/1.0/database_types/dbt-12345","name":"moxccmwwwhtn","description":"","disk_size":8192,"ram":2048},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.gb1.brightbox.com/1.0/zones/zon-12345","handle":"gb1-a"}}'
     http_version:
   recorded_at: Wed, 19 Feb 2014 17:01:31 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-lq52y?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 97758c306f49321310fa27d88f9d7b84973ab853
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:01:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"5bb0b93bc007804f2b243a7efd4f1fc5"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - a681bb99-8988-462a-be61-054bb49b348a
+      X-Runtime:
+      - '0.061734'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-lq52y","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-lq52y","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:01:41Z","updated_at":"2022-06-17T12:01:42Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:01:42 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-9mq1i?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 3cbabf1fbb28640e375330a3088159228258fa6b
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:03:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"be5a0c7786c21edf92ed05e65c2d759a"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 10c89ed7-4d7d-4628-bfd5-0f6ce68d83c9
+      X-Runtime:
+      - '0.052411'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-9mq1i","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-9mq1i","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:03:38Z","updated_at":"2022-06-17T12:03:38Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:03:38 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-c1ul5?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 76414b5916ba5e98f31ad7dd27d201ebe9f7da49
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:04:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"ef6b15ed100ac49d46eff87302abdc82"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 9bf1f09b-2f69-46cc-bc00-434f5a610733
+      X-Runtime:
+      - '0.043151'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-c1ul5","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-c1ul5","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:04:01Z","updated_at":"2022-06-17T12:04:01Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-b"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:04:01 GMT
 - request:
     method: post
     uri: http://api.brightbox.localhost/token
     body:
       encoding: UTF-8
-      string: "{\"grant_type\":\"client_credentials\"}"
+      string: '{"grant_type":"client_credentials"}'
     headers:
       User-Agent:
-      - fog/1.20.0
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
       Authorization:
-      - Basic YXBwLTEyMzQ1Om1vY2J1aXBiaWFhNms2Yw==
+      - Basic Y2xpLTEyMzQ1OnF5Nnh4bnZ5NG8wdGd2NQ==
       Content-Type:
       - application/json
   response:
     status:
-      code: 400
-      message:
+      code: 200
+      message: OK
     headers:
-      X-Frame-Options:
-      - sameorigin
-      X-Xss-Protection:
-      - 1; mode=block
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:03 GMT
       Content-Type:
-      - application/json;charset=utf-8
+      - application/json
+      Content-Length:
+      - '131'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
       Cache-Control:
       - no-store
-      Content-Length:
-      - '135'
-      X-Ua-Compatible:
-      - IE=Edge
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      X-Content-Type-Options:
+      - nosniff
+      Etag:
+      - W/"0aa12c18bb928be8f5134c13054a1db9"
       X-Request-Id:
-      - c1fcb87be6ccc540d7b758652ca7a2ca
+      - dba709fe-09a7-4506-990c-45867f40e672
       X-Runtime:
-      - '0.180078'
-      Server:
-      - WEBrick/1.3.1 (Ruby/1.9.3/2013-11-22)
-      Date:
-      - Wed, 19 Feb 2014 17:28:09 GMT
-      Connection:
-      - close
+      - '0.097244'
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a","token_type":"Bearer","scope":"infrastructure,
+        orbit","expires_in":7199}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:03 GMT
+- request:
+    method: post
+    uri: http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345
     body:
       encoding: UTF-8
-      string: "{\"error\":\"unauthorized_client\",\"error_description\":\"The authenticated
-        client is not authorized to use the access grant type provided.\"}"
+      string: '{"name":null,"description":null,"maintenance_weekday":null,"maintenance_hour":null,"snapshots_schedule":null}'
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1070'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Location:
+      - http://api.brightbox.localhost/1.0/database_servers/dbs-g8jia
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 2b55504e-f9a6-405c-940a-4c016c81aed3
+      X-Runtime:
+      - '0.319284'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-g8jia","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-g8jia","name":"","description":"","admin_username":"admin","admin_password":"i7b4265of52pcmh3","allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:03Z","updated_at":"2022-06-17T12:16:03Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
     http_version:
-  recorded_at: Wed, 19 Feb 2014 17:28:09 GMT
+  recorded_at: Fri, 17 Jun 2022 12:16:03 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-g8jia?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"3e09a9d91daad26621147dae425228c2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 5cb6c925-2d0f-4594-8fdd-ccc105f34968
+      X-Runtime:
+      - '0.056771'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-g8jia","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-g8jia","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:03Z","updated_at":"2022-06-17T12:16:03Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:04 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-g8jia?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"3e09a9d91daad26621147dae425228c2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 20f049ef-17cb-4e7a-9432-9b4cc1818155
+      X-Runtime:
+      - '0.053100'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-g8jia","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-g8jia","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"creating","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:03Z","updated_at":"2022-06-17T12:16:03Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:04 GMT
+- request:
+    method: get
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-g8jia?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1054'
+      Connection:
+      - keep-alive
+      Status:
+      - 200 OK
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Etag:
+      - W/"bbc9da1a34694949a6479abd03a6391b"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Request-Id:
+      - 48dd43d7-2621-4e37-b576-8cf9c50631ca
+      X-Runtime:
+      - '0.046309'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-g8jia","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-g8jia","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"active","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:03Z","updated_at":"2022-06-17T12:16:04Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:05 GMT
+- request:
+    method: delete
+    uri: http://api.brightbox.localhost/1.0/database_servers/dbs-g8jia?account_id=acc-12345
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.45.0
+      Proxy-Connection:
+      - Keep-Alive
+      Authorization:
+      - Bearer 62f6396c5e44f7fc9a424c5899ac2e9c3b23e27a
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Server:
+      - nginx/1.18.0
+      Date:
+      - Fri, 17 Jun 2022 12:16:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '1056'
+      Connection:
+      - keep-alive
+      Status:
+      - 202 Accepted
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Oauth-Scopes:
+      - infrastructure, orbit
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 847d4ecb-3166-4b4f-b960-1386d870efe0
+      X-Runtime:
+      - '0.165225'
+      Vary:
+      - Origin
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"dbs-g8jia","resource_type":"database_server","url":"https://api.brightbox.localhost/1.0/database_servers/dbs-g8jia","name":"","description":"","admin_username":"admin","admin_password":null,"allow_access":[],"database_engine":"mysql","database_version":"8.0","status":"deleting","locked":false,"maintenance_weekday":0,"maintenance_hour":6,"snapshots_retention":null,"snapshots_schedule":null,"snapshots_schedule_next_at":null,"created_at":"2022-06-17T12:16:03Z","updated_at":"2022-06-17T12:16:05Z","deleted_at":null,"account":{"id":"acc-12345","resource_type":"account","url":"https://api.brightbox.localhost/1.0/accounts/acc-12345","name":"CLI
+        test account","status":"active"},"database_server_type":{"id":"dbt-za5cu","resource_type":"database_type","url":"https://api.brightbox.localhost/1.0/database_types/dbt-za5cu","name":"Default
+        DBaaS","description":"","disk_size":20480,"ram":2048,"default":true},"cloud_ips":[],"zone":{"id":"zon-12345","resource_type":"zone","url":"https://api.brightbox.localhost/1.0/zones/zon-12345","handle":"honcho-a"}}'
+    http_version:
+  recorded_at: Fri, 17 Jun 2022 12:16:05 GMT
 recorded_with: VCR 2.5.0

--- a/spec/commands/sql/instances/create_spec.rb
+++ b/spec/commands/sql/instances/create_spec.rb
@@ -6,23 +6,30 @@ describe "brightbox sql instances" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    before do
-      config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+    let(:sql_instance) { Brightbox::DatabaseServer.get(new_id) }
+    let(:new_id) { stdout.match(/id: (.*?)\n/)[1] }
 
-      # Setup in the VCR recordings
-      cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
+    before do
+      config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+      Brightbox.config.reauthenticate
+    end
+
+    after do
+      sql_instance.wait_for { ready? }
+      sql_instance.destroy
     end
 
     context "without arguments", vcr: true do
       let(:argv) { %w(sql instances create) }
-      let(:expected_password) { "477wwwj48yifrnuk" }
 
       it "reports the new admin username" do
-        expect(stdout).to include("admin_username: admin")
+        username = sql_instance.admin_username
+        expect(stdout).to include("admin_username: #{username}")
       end
 
       it "reports the new admin password" do
-        expect(stdout).to include("admin_password: #{expected_password}")
+        expected_password = sql_instance.admin_password
+        expect(stdout).to include("admin_password:")
       end
     end
 
@@ -32,17 +39,27 @@ describe "brightbox sql instances" do
 
       it "correctly sends API parameters" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stderr).to eql("")
+        expect(stderr).to eq("")
       end
     end
 
     context "--allow-access=srv-12345,grp-12345", vcr: true do
-      let(:argv) { %w(sql instances create --allow-access srv-12345,grp-12345) }
-      let(:expected_args) { { :allow_access => %w(srv-12345 grp-12345) } }
+      let(:argv) { ["sql", "instances", "create", "--allow-access", "#{server.id},#{group.id}"] }
+      let(:expected_args) { { :allow_access => [server.id, group.id] } }
+      let(:group) { Brightbox::ServerGroup.all.first }
+      let(:server) { Brightbox::Server.create flavor_id: "2gb.nbs", image_id: "img-linux" }
+
+      before do
+        server.fog_model.wait_for { ready? }
+      end
 
       it "correctly sends API parameters" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stderr).to eql("")
+        expect(stderr).to eq("")
+      end
+
+      after do
+        server.destroy
       end
     end
 
@@ -52,108 +69,74 @@ describe "brightbox sql instances" do
 
       it "correctly sends API parameters" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stderr).to eql("")
+        expect(stderr).to eq("")
+        expect(stdout).to include("version: 8.0")
       end
     end
 
-    context "--engine=mysql --engine-version=5.6", vcr: true do
-      let(:argv) { %w(sql instances create --engine=mysql --engine-version=5.6) }
-      let(:expected_args) { { :database_engine => "mysql", :database_version => "5.6" } }
+    context "--engine=mysql --engine-version=8.0", vcr: true do
+      let(:argv) { %w(sql instances create --engine=mysql --engine-version=8.0) }
+      let(:expected_args) { { :database_engine => "mysql", :database_version => "8.0" } }
 
       it "correctly sends API parameters" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stderr).to eql("")
+        expect(stderr).to eq("")
+        expect(stdout).to include("version: 8.0")
       end
     end
 
-    context "--maintenance-weekday=5 --maintenance_hour=11" do
+    context "--maintenance-weekday=5 --maintenance_hour=11", vcr: true do
       let(:argv) { %w(sql instances create --maintenance-weekday=5 --maintenance-hour=11) }
       let(:expected_args) { { :maintenance_weekday => "5", :maintenance_hour => "11" } }
 
-      before do
-        stub_request(:post, "http://api.brightbox.localhost/token").to_return(
-          :status => 200,
-          :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}')
-
-        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
-          .with(:body => "{\"name\":null,\"description\":null,\"maintenance_weekday\":\"5\",\"maintenance_hour\":\"11\"}")
-      end
-
       it "correctly sends API parameters" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stderr).to eql("")
+        expect(stderr).to eq("")
       end
     end
 
-    context "--maintenance-weekday=thursday" do
+    context "--maintenance-weekday=thursday", vcr: true do
       let(:argv) { %w(sql instances create --maintenance-weekday=thursday) }
       let(:expected_args) { { :maintenance_weekday => "4" } }
 
-      before do
-        stub_request(:post, "http://api.brightbox.localhost/token").to_return(
-          :status => 200,
-          :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}')
-
-        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
-          .with(:body => "{\"name\":null,\"description\":null,\"maintenance_weekday\":\"4\",\"maintenance_hour\":null}")
-      end
-
       it "correctly sends API parameters" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stderr).to eql("")
+        expect(stderr).to eq("")
       end
     end
 
-    context "--snapshot=dbi-1493j" do
-      let(:argv) { ["sql", "instances", "create", "--snapshot=dbi-1493j"] }
-      let(:expected_args) { { :snapshot_id => "dbi-1493j" } }
-
-      let(:json_response) do
-        <<-EOS
-        {
-          "id":"dbs-12345"
-        }
-        EOS
-      end
+    context "--snapshot=dbi-12345", vcr: true do
+      let(:argv) { ["sql", "instances", "create", "--snapshot=#{sql_snapshot.id}"] }
+      let(:expected_args) { { :snapshot_id => sql_snapshot.id } }
+      let(:source) { Brightbox::DatabaseServer.create({}) }
+      let(:sql_snapshot) { source.snapshot(true) }
 
       before do
-        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
-          .with(:headers => { "Content-Type" => "application/json" },
-                :body => hash_including("snapshot" => "dbi-1493j"))
-          .and_return(:status => 202, :body => json_response)
+        source.fog_model.wait_for { ready? }
+        sql_snapshot.wait_for { ready? }
+      end
+
+      after do
+        source.destroy
+        sql_snapshot.destroy
       end
 
       it "includes schedule fields in response" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
-        expect(stdout).to include("id: dbs-12345")
-        expect(stderr).to eql("")
+        expect(stdout).to include("id: #{sql_instance.id}")
+        expect(stderr).to eq("")
       end
     end
 
-    context "--snapshots-schedule='0 12 * * 4'" do
+    context "--snapshots-schedule='0 12 * * 4'", vcr: true do
       let(:argv) { ["sql", "instances", "create", "--snapshots-schedule=0 12 * * 4"] }
       let(:expected_args) { { :snapshots_schedule => "0 12 * * 4" } }
-
-      let(:json_response) do
-        <<-EOS
-        {
-          "id":"dbs-12345",
-          "snapshots_schedule":"0 12 * * 4",
-          "snapshots_schedule_next_at":"2016-07-07T12:00:00Z"
-        }
-        EOS
-      end
-
-      before do
-        stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers?account_id=acc-12345")
-          .and_return(:status => 202, :body => json_response)
-      end
 
       it "includes schedule fields in response" do
         expect(Brightbox::DatabaseServer).to receive(:create).with(expected_args).and_call_original
         expect(stdout).to include("snapshots_schedule: 0 12 * * 4")
-        expect(stdout).to include("snapshots_schedule_next_at: 2016-07-07T12:00Z")
-        expect(stderr).to eql("")
+        expect(stdout).to match(/snapshots_schedule_next_at: 20\d{2}-\d{2}-\d{2}T12:\d{2}Z/)
+        expect(stderr).to eq("")
       end
     end
   end


### PR DESCRIPTION
This update includes support for volume resources but have not been
added to the CLI yet.

This also updates a number of VCR recordings that failed to replay to
changes in the `fog-brightbox` implementation that resulted in missed
matches due to changes in the request format.