### PR TITLE
Setup `rubocop` for code quality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,70 @@
+AllCops:
+  NewCops: enable
+  Exclude:
+    - bin/*
+    - lib/brightbox-cli/vendor/**/*
+    - vendor/**/*
+  TargetRubyVersion: 2.5
+
+Layout/HeredocIndentation:
+  Enabled: true
+
+Layout/LineLength:
+  Enabled: false
+  Max: 100
+
+Lint/SuppressedException:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/Encoding:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/HashSyntax:
+  Enabled: true
+  EnforcedStyle: no_mixed_keys
+
+Style/GlobalVars:
+  Enabled: false # It's horrid, there's so many
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/SignalException:
+  # Valid values are: semantic, only_raise and only_fail
+  EnforcedStyle: only_raise
+
+Style/SingleLineMethods:
+  Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -46,6 +47,9 @@ GEM
     mime-types (2.99.3)
     mocha (1.14.0)
     multi_json (1.11.3)
+    parallel (1.22.1)
+    parser (3.1.2.0)
+      ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -53,7 +57,9 @@ GEM
       pry (~> 0.9)
       slop (~> 3.0)
     public_suffix (4.0.7)
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
     rspec (3.11.0)
       rspec-core (~> 3.11.0)
@@ -68,7 +74,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    rubocop (1.28.2)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.17.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.17.0)
+      parser (>= 3.1.1.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.10.0)
+      rubocop (~> 1.19)
+    ruby-progressbar (1.11.0)
     slop (3.6.0)
+    unicode-display_width (2.1.0)
     vcr (2.9.3)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -84,6 +107,9 @@ DEPENDENCIES
   pry-remote
   rake
   rspec
+  rubocop
+  rubocop-rake
+  rubocop-rspec
   vcr (~> 2.5)
   webmock
 

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+
 require File.join(File.dirname(__FILE__), "lib/brightbox-cli/version")
 
 Gem::Specification.new do |s|
@@ -8,8 +9,8 @@ Gem::Specification.new do |s|
   s.authors     = ["John Leach"]
   s.email       = ["john@brightbox.co.uk"]
   s.homepage    = "http://docs.brightbox.com/cli"
-  s.summary     = %q(The Brightbox cloud management system)
-  s.description = %q(Scripts to interact with the Brightbox cloud API)
+  s.summary     = "The Brightbox cloud management system"
+  s.description = "Scripts to interact with the Brightbox cloud API"
   s.license     = "MIT"
 
   s.required_ruby_version = ">= 2.5"
@@ -22,16 +23,19 @@ Gem::Specification.new do |s|
   s.add_dependency "fog-brightbox", ">= 1.5.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21.0"
+  s.add_dependency "highline", "~> 1.6.0"
+  s.add_dependency "hirb", "~> 0.6"
   s.add_dependency "i18n", ">= 0.6", "< 1.11"
   s.add_dependency "mime-types", "~> 2.6"
   s.add_dependency "multi_json", "~> 1.11.0"
-  s.add_dependency "highline", "~> 1.6.0"
-  s.add_dependency "hirb", "~> 0.6"
 
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-remote"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
+  s.add_development_dependency "rubocop"
+  s.add_development_dependency "rubocop-rake"
+  s.add_development_dependency "rubocop-rspec"
   s.add_development_dependency "vcr", "~> 2.5"
   s.add_development_dependency "webmock"
 end


### PR DESCRIPTION
This was used but inconsistently applied without a centralised config.
This moves the current config into place as well as adding the gems to
the development list.