### PR TITLE
Add tests for 2FA login

### DIFF
--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -298,4 +298,51 @@ describe "brightbox login" do
       expect(stderr).to_not include("please re-run your command")
     end
   end
+
+  context "when user has 2FA set up" do
+    let(:config) { Brightbox::BBConfig.new client_name: email }
+    let(:contents) do
+      <<-EOS
+      [core]
+      default_client = #{client_alias}
+
+      [#{client_alias}]
+      username = #{email}
+      default_account = #{default_account}
+      two_factor = true
+      EOS
+    end
+
+    context "when no password is given" do
+      let(:argv) { ["login", email] }
+
+      before do
+        config_from_contents(contents)
+        stub_token_request(two_factor: true)
+        stub_accounts_request
+        mock_password_entry(password)
+        mock_otp_entry("123456")
+      end
+
+      it "prompts for the password" do
+        expect { output }.not_to raise_error
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+        expect(stderr).to_not include("ERROR")
+      end
+
+      it "requests access tokens" do
+        expect { output }.to_not raise_error
+
+        expect(cached_access_token(config)).to eql(config.access_token)
+        expect(cached_refresh_token(config)).to eql(config.refresh_token)
+      end
+
+      it "does not prompt to rerun the command" do
+        expect(stderr).to_not include("please re-run your command")
+      end
+    end
+  end
 end

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -23,11 +23,13 @@ describe "brightbox login" do
     end
   end
 
-  context "when no config is present", vcr: true do
+  context "when no config is present" do
     let(:argv) { ["login", "-p", password, email] }
 
     before do
       remove_config
+      stub_token_request
+      stub_accounts_request
     end
 
     it "does not error" do
@@ -60,11 +62,13 @@ describe "brightbox login" do
     end
   end
 
-  context "when no password is given", vcr: true do
+  context "when no password is given" do
     let(:argv) { ["login", email] }
 
     before do
       remove_config
+      stub_token_request
+      stub_accounts_request
       mock_password_entry(password)
     end
 
@@ -102,16 +106,15 @@ describe "brightbox login" do
     end
   end
 
-  context "when custom api/auth URLs are given", vcr: true do
-    # FIXME: These need to be the "real" defaults to record the token interchange
-    #        May allow a regression that the defaults are used, not the passed argument
-    #        Need to use something better that VCR.
+  context "when custom api/auth URLs are given" do
     let(:api_url) { Brightbox::DEFAULT_API_ENDPOINT }
     let(:auth_url) { Brightbox::DEFAULT_API_ENDPOINT }
     let(:argv) { ["login", "--api-url", api_url, "--auth-url", auth_url, email] }
 
     before do
       remove_config
+      stub_token_request
+      stub_accounts_request
       mock_password_entry(password)
     end
 
@@ -150,12 +153,13 @@ describe "brightbox login" do
     end
   end
 
-  context "when default account is passed", vcr: true do
+  context "when default account is passed" do
     let(:account) { "acc-23456" }
     let(:argv) { ["login", "--default-account", account, email] }
 
     before do
       remove_config
+      stub_token_request
       mock_password_entry(password)
     end
 
@@ -194,13 +198,15 @@ describe "brightbox login" do
     end
   end
 
-  context "when alternative client credentials are given", vcr: true do
+  context "when alternative client credentials are given" do
     let(:other_client_identifier) { "app-23456" }
     let(:other_client_secret) { "ho04hondtzjjdf4" }
     let(:argv) { ["login", "--application-id", other_client_identifier, "--application-secret", other_client_secret, email] }
 
     before do
       remove_config
+      stub_token_request
+      stub_accounts_request
       mock_password_entry(password)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,7 @@ Fog.timeout = 10
 RSpec.configure do |config|
   config.include CommonHelpers
   config.include ConfigHelpers
+  config.include AuthenticationHelpers
   config.include TokenHelpers
   config.include PasswordPromptHelpers
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,10 @@ RSpec.configure do |config|
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
+  config.expect_with :rspec do |c|
+    c.max_formatted_output_length = nil
+  end
+
   config.before do
     # For each test, point to the testing endpoint to make it safer and easier to
     # record from dev endpoints. Devs can DNS api.brightbox.localhost to their dev service

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,87 @@
+module AuthenticationHelpers
+  def stub_token_request(two_factor: false)
+    auth_response = {
+      status: 200,
+      body: {
+        access_token: "17e9282e40b8a2f1366107a068a1632bb65d3dec",
+        token_type: "Bearer",
+        refresh_token: "b77913a13cccfdd44294b4b161494a652d48b635",
+        scope: "infrastructure, orbit",
+        expires_in: 7200
+      }.to_json
+    }
+
+    if two_factor
+      stub_request(:post, "#{api_url}/token")
+        .with(
+          body: {
+            grant_type: "password",
+            username: "jason.null@brightbox.com",
+            password: "N:B3e%7Cmh"
+          }.to_json
+        )
+        .to_return(
+          status: 401,
+          headers: {
+            "X-Brightbox-OTP" => "required"
+          },
+          body: { error: "invalid_client" }.to_json
+        )
+
+      stub_request(:post, "#{api_url}/token")
+        .with(
+          headers: {
+            "X-Brightbox-OTP" => "123456"
+          },
+          body: {
+            grant_type: "password",
+            username: "jason.null@brightbox.com",
+            password: "N:B3e%7Cmh+123456"
+          }.to_json
+        )
+        .to_return(auth_response)
+    else
+      stub_request(:post, "#{api_url}/token")
+        .with(
+          body: {
+            grant_type: "password",
+            username: "jason.null@brightbox.com",
+            password: "N:B3e%7Cmh"
+          }.to_json
+        )
+        .to_return(auth_response)
+    end
+  end
+
+  def stub_accounts_request
+    stub_request(:get, "#{api_url}/1.0/accounts?nested=false")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: [
+          {
+            id: "acc-12345",
+            resource_type: "account",
+            url: "https://api.gb1.brightbox.com/1.0/accounts/acc-12345",
+            name: "CLI test account",
+            status: "active",
+            ram_limit: 3_200_000,
+            ram_used: 0,
+            dbs_ram_limit: 32_768,
+            dbs_ram_used: 0,
+            cloud_ips_limit: 32,
+            cloud_ips_used: 0,
+            load_balancers_limit: 5,
+            load_balancers_used: 0,
+            owner: {
+              id: "usr-12345",
+              resource_type: "user",
+              url: "https://api.gb1.brightbox.com/1.0/users/usr-12345",
+              name: "Jason Null",
+              email_address: "jason.null@brightbox.com"
+            }
+          }
+        ].to_json
+      )
+  end
+end

--- a/spec/support/password_prompt_helpers.rb
+++ b/spec/support/password_prompt_helpers.rb
@@ -6,10 +6,31 @@ module PasswordPromptHelpers
     "N:B3e%7Cmh"
   end
 
+  # Intercepts HighLine prompts for a one-time password (OTP) used as part of
+  # two factor authentication (2FA). The prevents blocking the spec waiting for
+  # input.
+  #
+  def mock_otp_entry(otp = "123456")
+    input = instance_double(HighLine)
+
+    expect(input).to receive(:ask).with("Enter your two factor pin : ")
+                                  .once
+                                  .and_return(otp)
+
+    expect(HighLine).to receive(:new).once.and_return(input)
+  end
+
   # Intercepts HighLine prompting for a password and returns the testing default
   # or a specific value. Otherwise this blocks the specs.
   #
   def mock_password_entry(password = default_test_password)
-    expect_any_instance_of(HighLine).to receive(:ask).at_least(:once).and_return(password)
+    input = instance_double(HighLine)
+
+    allow(input).to receive(:say).with("Your API credentials have expired, enter your password to update them.")
+    expect(input).to receive(:ask).with("Enter your password : ")
+                                  .once
+                                  .and_return(password)
+
+    expect(HighLine).to receive(:new).once.and_return(input)
   end
 end


### PR DESCRIPTION
There is a configurable flag to enable the `login` command to support 2FA (offering a separate prompt) but it was not tested.

This adds helpers and replaces the VCR fixtures that do not allow us to mock the traffic we need to test this.