### PR TITLE
Support Two Factor Authentication (2FA) properly

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    dry-inflector (0.3.0)
+    dry-inflector (0.2.0)
     excon (0.92.4)
     fog-brightbox (1.6.0)
       dry-inflector

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (4.0.0.rc1)
-      fog-brightbox (>= 1.5.0)
+      fog-brightbox (>= 1.6.0)
       fog-core (< 2.0)
       gli (~> 2.21.0)
       highline (~> 1.6.0)
@@ -23,9 +23,9 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    dry-inflector (0.2.0)
-    excon (0.92.3)
-    fog-brightbox (1.5.0)
+    dry-inflector (0.3.0)
+    excon (0.92.4)
+    fog-brightbox (1.6.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.5.0"
+  s.add_dependency "fog-brightbox", ">= 1.6.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21.0"
   s.add_dependency "highline", "~> 1.6.0"

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -39,7 +39,18 @@ module Brightbox
       section_options[:client_id] = options[:"application-id"] if options[:"application-id"]
       section_options[:secret] = options[:"application-secret"] if options[:"application-secret"]
 
-      Brightbox.config.add_login(email, password, section_options)
+      begin
+        Brightbox.config.add_login(email, password, section_options)
+      rescue Fog::Brightbox::OAuth2::TwoFactorMissingError
+        section_options = {
+          :client_name => config_name,
+          :alias => config_name,
+          :username => email,
+          :password => password,
+          :one_time_password => discover_two_factor_pin
+        }
+        Brightbox.config.add_login(email, password, section_options)
+      end
     end
   end
 end

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -21,18 +21,8 @@ module Brightbox
 
       raise "You must specify your email address" if email.nil?
 
-      password = options[:p]
-      password ||= Brightbox.config.gpg_password
-      password ||= Brightbox.config.password_helper_password
-
-      if !password || password.empty?
-        require "highline"
-        highline = HighLine.new
-        password = highline.ask("Enter your password : ") { |q| q.echo = false }
-      end
+      password = Brightbox.config.discover_password(password: options[:p])
       raise "You must specify your Brightbox password." if password.empty?
-
-      password = Brightbox.config.extend_with_two_factor_pin(password)
 
       section_options = {
         :client_name => config_name,

--- a/lib/brightbox-cli/config/authentication_tokens.rb
+++ b/lib/brightbox-cli/config/authentication_tokens.rb
@@ -174,23 +174,10 @@ module Brightbox
         connection
       end
 
-      # This asks the user to input their password
-      def prompt_for_password
-        require "highline"
-        highline = HighLine.new
-        highline.say("Your API credentials have expired, enter your password to update them.")
-        # FIXME: Capture interupts if user aborts
-        highline.ask("Enter your password : ") { |q| q.echo = false }
-      end
-
       def update_tokens_with_user_credentials(password = nil)
         user_application = Brightbox::Config::UserApplication.new(selected_config, client_name)
 
-        password ||= gpg_password
-        password ||= password_helper_password
-        password ||= prompt_for_password
-
-        password = extend_with_two_factor_pin(password)
+        password = discover_password(password: password, expired: true)
 
         # FIXME: options are required to work
         options = {

--- a/lib/brightbox-cli/config/password_helper.rb
+++ b/lib/brightbox-cli/config/password_helper.rb
@@ -1,7 +1,30 @@
 module Brightbox
   module Config
     module PasswordHelper
+      ENTER_PASSWORD_PROMPT = "Enter your password : ".freeze
+      EXPIRED_TOKEN_PROMPT = "Your API credentials have expired, enter your password to update them.".freeze
+
       attr_writer :password_helper_password
+
+      # {discover_password} will return the first password that can be
+      # recovered from either the passed input, encrypted storage, a
+      # helper application (if configured) or finally promping.
+      #
+      # @param password [String] a password given to the method
+      # @param expired [Boolean] should the prompt explain tokens have expired?
+      # @return [String] the password
+      #
+      def discover_password(password: nil, expired: false)
+        password ||= gpg_password
+        password ||= password_helper_password
+        password ||= prompt_for_password(expired)
+
+        # Current workaround for 2FA support is to check for config and
+        # append OTP to password
+        extend_with_two_factor_pin(password)
+      end
+
+      private
 
       def password_helper_command
         return config[client_name]["password_helper_command"] unless client_name.nil?
@@ -18,8 +41,6 @@ module Brightbox
                                     end
       end
 
-      private
-
       def password_helper_call
         info "INFO: Calling password helper to obtain password"
         begin
@@ -30,6 +51,16 @@ module Brightbox
         rescue Errno::ENOENT
           nil
         end
+      end
+
+      # This asks the user to input their password
+      def prompt_for_password(expired)
+        require "highline"
+        highline = HighLine.new
+        highline.say(EXPIRED_TOKEN_PROMPT) if expired
+
+        # FIXME: Capture interupts if user aborts
+        highline.ask(ENTER_PASSWORD_PROMPT) { |q| q.echo = false }
       end
     end
   end

--- a/lib/brightbox-cli/config/password_helper.rb
+++ b/lib/brightbox-cli/config/password_helper.rb
@@ -18,10 +18,6 @@ module Brightbox
         password ||= gpg_password
         password ||= password_helper_password
         password ||= prompt_for_password(expired)
-
-        # Current workaround for 2FA support is to check for config and
-        # append OTP to password
-        extend_with_two_factor_pin(password)
       end
 
       private

--- a/lib/brightbox-cli/config/sections.rb
+++ b/lib/brightbox-cli/config/sections.rb
@@ -44,17 +44,17 @@ module Brightbox
         begin
           remove_cached_tokens!
           renew_tokens(:client_name => config_alias, :password => password)
+
+          # Try to determine a default account
+          unless default_account == find_or_set_default_account
+            info "The default account of #{default_account} has been selected"
+          end
+
+          # If only client then set it as the default
+          set_default_client(client_alias) unless default_client
         rescue StandardError => e
           error "Something went wrong trying to refresh new tokens #{e.message}"
         end
-
-        # Try to determine a default account
-        unless default_account == find_or_set_default_account
-          info "The default account of #{default_account} has been selected"
-        end
-
-        # If only client then set it as the default
-        set_default_client(client_alias) unless default_client
 
         # Ensure all our config changes are now saved
         save

--- a/lib/brightbox-cli/config/two_factor_auth.rb
+++ b/lib/brightbox-cli/config/two_factor_auth.rb
@@ -1,11 +1,27 @@
 module Brightbox
   module Config
     module TwoFactorAuth
+      ENTER_TWO_FACTOR_PROMPT = "Enter your two factor pin : ".freeze
+
+      attr_accessor :current_second_factor
+
+      def discover_two_factor_pin
+        return unless two_factor_enabled
+
+        @two_factor_pin ||= Brightbox.config.two_factor_helper_password
+        @two_factor_pin ||= prompt_for_two_factor_pin
+      end
+
       def extend_with_two_factor_pin(password)
-        if two_factor_enabled
-          suffix = "+#{two_factor_pin}"
-          password += suffix unless password.end_with?(suffix)
-        end
+        return password unless two_factor_enabled
+
+        # Make the OTP available in the configuration
+        self.current_second_factor = discover_two_factor_pin
+        return password unless current_second_factor
+
+        # This is a workaround to send the OTP appended to password
+        suffix = "+#{current_second_factor}"
+        password += suffix unless password.end_with?(suffix)
         password
       end
 
@@ -15,18 +31,11 @@ module Brightbox
         return config[client_name]["two_factor"] == "true" unless client_name.nil?
       end
 
-      def two_factor_pin
-        return unless two_factor_enabled
-
-        @two_factor_pin ||= Brightbox.config.two_factor_helper_password
-        @two_factor_pin ||= prompt_for_two_factor_pin
-      end
-
       def prompt_for_two_factor_pin
         require "highline"
         highline = HighLine.new
         # FIXME: Capture interupts if user aborts
-        highline.ask("Enter your two factor pin : ")
+        highline.ask(ENTER_TWO_FACTOR_PROMPT)
       end
     end
   end

--- a/lib/brightbox-cli/config/two_factor_auth.rb
+++ b/lib/brightbox-cli/config/two_factor_auth.rb
@@ -6,29 +6,19 @@ module Brightbox
       attr_accessor :current_second_factor
 
       def discover_two_factor_pin
-        return unless two_factor_enabled
-
         @two_factor_pin ||= Brightbox.config.two_factor_helper_password
         @two_factor_pin ||= prompt_for_two_factor_pin
-      end
 
-      def extend_with_two_factor_pin(password)
-        return password unless two_factor_enabled
-
-        # Make the OTP available in the configuration
-        self.current_second_factor = discover_two_factor_pin
-        return password unless current_second_factor
-
-        # This is a workaround to send the OTP appended to password
-        suffix = "+#{current_second_factor}"
-        password += suffix unless password.end_with?(suffix)
-        password
+        self.current_second_factor = @two_factor_pin
       end
 
       private
 
       def two_factor_enabled
-        return config[client_name]["two_factor"] == "true" unless client_name.nil?
+        return false unless client_name.nil?
+        return true if config[client_name]["two_factor"] == "true"
+
+        false
       end
 
       def prompt_for_two_factor_pin

--- a/lib/brightbox-cli/config/two_factor_helper.rb
+++ b/lib/brightbox-cli/config/two_factor_helper.rb
@@ -27,7 +27,7 @@ module Brightbox
           IO.popen(cmd, "r") do |io|
             io.readline.chomp
           end
-        rescue Errno::ENOENT
+        rescue ArgumentError, Errno::ENOENT
           nil
         end
       end

--- a/lib/brightbox-cli/config/user_application.rb
+++ b/lib/brightbox-cli/config/user_application.rb
@@ -21,6 +21,7 @@ module Brightbox
           :brightbox_auth_url => selected_config["auth_url"] || selected_config["api_url"],
           :brightbox_client_id => client_id,
           :brightbox_secret => client_secret,
+          :brightbox_support_two_factor => true,
           :persistent => persistent?
         }
       end
@@ -40,7 +41,9 @@ module Brightbox
       #
       def fetch_refresh_token(options)
         password_options = {
-          :brightbox_password => options[:password]
+          :brightbox_password => options[:password],
+          :brightbox_support_two_factor => true,
+          :brightbox_one_time_password => options[:one_time_password]
         }
 
         default_fog_options = password_auth_params.merge(password_options)
@@ -75,6 +78,7 @@ module Brightbox
           :brightbox_client_id => client_id,
           :brightbox_secret => client_secret,
           :brightbox_username => selected_config["username"],
+          :brightbox_support_two_factor => true,
           :persistent => persistent?
         }
       end

--- a/lib/brightbox-cli/connection_manager.rb
+++ b/lib/brightbox-cli/connection_manager.rb
@@ -27,6 +27,8 @@ module Brightbox
 
     def connection_options
       merged_options = @connection_options.dup
+      merged_options.update(:brightbox_support_two_factor => true)
+
       if @connection&.refresh_token
         merged_options.update(:brightbox_refresh_token => @connection.refresh_token)
       end

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -43,31 +43,6 @@ describe "brightbox login" do
             status: 401,
             body: { error: "invalid_client" }.to_json
           )
-
-          # FIXME: Phantom follow up as a client
-          stub_request(:post, "#{api_url}/token")
-            .with(
-              body: {
-                grant_type: "client_credentials"
-              }.to_json
-            ).to_return(
-              status: 400,
-              body: {
-                "error": "unauthorized_client",
-                "error_description": "The authenticated client is not authorized to use the access grant type provided."
-              }.to_json
-            )
-
-          # FIXME: Attempt to access accounts list and fail
-          stub_request(:get, "#{api_url}/1.0/accounts?nested=false")
-            .to_return(
-              status: 401,
-              body: {
-                "error": "invalid_request",
-                "error_description": "OAuth token was not sent as Authorization header"
-              }.to_json
-            )
-
       end
 
       it "does not error" do

--- a/spec/commands/login_spec.rb
+++ b/spec/commands/login_spec.rb
@@ -348,47 +348,50 @@ describe "brightbox login" do
 
   context "when user has 2FA set up" do
     let(:config) { Brightbox::BBConfig.new client_name: email }
-    let(:contents) do
-      <<-EOS
-      [core]
-      default_client = #{client_alias}
 
-      [#{client_alias}]
-      username = #{email}
-      default_account = #{default_account}
-      two_factor = true
-      EOS
-    end
+    context "with existing configuration" do
+      let(:contents) do
+        <<-EOS
+        [core]
+        default_client = #{client_alias}
 
-    context "when no password is given" do
-      let(:argv) { ["login", email] }
-
-      before do
-        config_from_contents(contents)
-        stub_token_request(two_factor: true)
-        stub_accounts_request
-        mock_password_entry(password)
-        mock_otp_entry("123456")
+        [#{client_alias}]
+        username = #{email}
+        default_account = #{default_account}
+        two_factor = true
+        EOS
       end
 
-      it "prompts for the password" do
-        expect { output }.not_to raise_error
-      end
+      context "when no password is given" do
+        let(:argv) { ["login", email] }
 
-      it "does not error" do
-        expect { output }.to_not raise_error
-        expect(stderr).to_not include("ERROR")
-      end
+        before do
+          config_from_contents(contents)
+          stub_token_request(two_factor: true)
+          stub_accounts_request
+          mock_password_entry(password)
+          mock_otp_entry("123456")
+        end
 
-      it "requests access tokens" do
-        expect { output }.to_not raise_error
+        it "prompts for the password" do
+          expect { output }.not_to raise_error
+        end
 
-        expect(cached_access_token(config)).to eql(config.access_token)
-        expect(cached_refresh_token(config)).to eql(config.refresh_token)
-      end
+        it "does not error" do
+          expect { output }.to_not raise_error
+          expect(stderr).to_not include("ERROR")
+        end
 
-      it "does not prompt to rerun the command" do
-        expect(stderr).to_not include("please re-run your command")
+        it "requests access tokens" do
+          expect { output }.to_not raise_error
+
+          expect(cached_access_token(config)).to eql(config.access_token)
+          expect(cached_refresh_token(config)).to eql(config.refresh_token)
+        end
+
+        it "does not prompt to rerun the command" do
+          expect(stderr).to_not include("please re-run your command")
+        end
       end
     end
   end

--- a/spec/unit/brightbox/config/discover_two_factor_pin_spec.rb
+++ b/spec/unit/brightbox/config/discover_two_factor_pin_spec.rb
@@ -1,0 +1,103 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::Config, "#discover_two_factor_pin" do
+  subject(:config) { config_from_contents(contents) }
+
+  let(:api_url) { "http://api.brightbox.localhost" }
+  let(:client_alias) { email }
+  let(:default_account) { "acc-12345" }
+  let(:email) { "jason.null@brightbox.com" }
+
+  context "when 2FA is not enabled" do
+    let(:contents) do
+      <<-EOS
+      [core]
+      default_client = #{client_alias}
+
+      [#{client_alias}]
+      username = #{email}
+      EOS
+    end
+
+    it "returns nil" do
+      expect(config.discover_two_factor_pin).to be_nil
+    end
+  end
+
+  context "when 2FA is enabled" do
+    context "with password helper" do
+      let(:cmd) { "fnord" }
+      let(:contents) do
+        <<-EOS
+        [core]
+        default_client = #{client_alias}
+
+        [#{client_alias}]
+        username = #{email}
+        two_factor = true
+        two_factor_helper_command = #{cmd}
+        EOS
+      end
+
+      it "returns helper's response" do
+        expect(IO).to receive(:popen).with([cmd], "r").and_return("111111")
+
+        expect(config.discover_two_factor_pin).to eq("111111")
+      end
+    end
+
+    context "with invalid password helper" do
+      let(:contents) do
+        <<-EOS
+        [core]
+        default_client = #{client_alias}
+
+        [#{client_alias}]
+        username = #{email}
+        two_factor = true
+        two_factor_helper_command = #{cmd}
+        EOS
+      end
+
+      context "when setting is empty" do
+        let(:cmd) { nil }
+
+        it "prompts for OTP" do
+          mock_otp_entry("123456")
+
+          expect(config.discover_two_factor_pin).to eq("123456")
+        end
+      end
+
+      context "when command doesn't exist" do
+        let(:cmd) { "fnord" }
+
+        it "prompts for OTP" do
+          expect(IO).to receive(:popen).with([cmd], "r").and_raise(Errno::ENOENT)
+          mock_otp_entry("123456")
+
+          expect(config.discover_two_factor_pin).to eq("123456")
+        end
+      end
+    end
+
+    context "without password helper" do
+      let(:contents) do
+        <<-EOS
+        [core]
+        default_client = #{client_alias}
+
+        [#{client_alias}]
+        username = #{email}
+        two_factor = true
+        EOS
+      end
+
+      it "prompts for OTP" do
+        mock_otp_entry("123456")
+
+        expect(config.discover_two_factor_pin).to eq("123456")
+      end
+    end
+  end
+end

--- a/spec/unit/brightbox/config/discover_two_factor_pin_spec.rb
+++ b/spec/unit/brightbox/config/discover_two_factor_pin_spec.rb
@@ -8,22 +8,6 @@ RSpec.describe Brightbox::Config, "#discover_two_factor_pin" do
   let(:default_account) { "acc-12345" }
   let(:email) { "jason.null@brightbox.com" }
 
-  context "when 2FA is not enabled" do
-    let(:contents) do
-      <<-EOS
-      [core]
-      default_client = #{client_alias}
-
-      [#{client_alias}]
-      username = #{email}
-      EOS
-    end
-
-    it "returns nil" do
-      expect(config.discover_two_factor_pin).to be_nil
-    end
-  end
-
   context "when 2FA is enabled" do
     context "with password helper" do
       let(:cmd) { "fnord" }


### PR DESCRIPTION
This enables the new option in `fog-brightbox v1.6.0` which will raise a
different error if a user's authentication fails due to them having Two
Factor Authentication (2FA) enabled but not supplying a One Time
Password (OTP).

This results in prompts for a user's OTP during certain actions such as
the `login` command or when tokens have expired and are being renewed.

This replaces the functionality enabled by the `two_factor` setting in
configurations. 2FA enrolment is automatically discovered or ignored.