### PR TITLE
Add `min-ram` argument to Images

### DIFF
--- a/lib/brightbox-cli/commands/images/register.rb
+++ b/lib/brightbox-cli/commands/images/register.rb
@@ -25,6 +25,9 @@ module Brightbox
       c.default_value "false"
       c.flag [:p, "public"]
 
+      c.desc "Set minimum amount of RAM required by this image (MB)"
+      c.flag ["min-ram"]
+
       c.action do |global_options, options, _args|
         raise "You must specify the architecture" unless options[:a]
         raise "You must specify the source filename" unless options[:s]
@@ -39,7 +42,8 @@ module Brightbox
           :name => options[:n], :arch => options[:a],
           :username => options[:u], :source => options[:s],
           :compatibility_mode => compatibility_flag,
-          :description => options[:d], :public => public_flag
+          :description => options[:d], :public => public_flag,
+          :min_ram => options["min-ram"].to_i
         }
 
         image = Image.register(image_options)

--- a/lib/brightbox-cli/commands/images/show.rb
+++ b/lib/brightbox-cli/commands/images/show.rb
@@ -26,6 +26,7 @@ module Brightbox
             official
             ancestor_id
             licence_name
+            min_ram
           ]
         }
 

--- a/lib/brightbox-cli/commands/images/update.rb
+++ b/lib/brightbox-cli/commands/images/update.rb
@@ -18,6 +18,9 @@ module Brightbox
       c.desc "Set image to be publicly visible (true or false)"
       c.flag [:p, "public"]
 
+      c.desc "Set minimum amount of RAM required by this image (MB)"
+      c.flag ["min-ram"]
+
       c.desc "Set image to be deprecated (true or false)"
       c.flag "deprecated"
 
@@ -47,6 +50,8 @@ module Brightbox
 
         params[:public] = true if options[:p] == "true"
         params[:public] = false if options[:p] == "false"
+
+        params[:min_ram] = options["min-ram"].to_i if options["min-ram"]
 
         # If options[:deprecated] isn't specified, leave the status alone
         params[:status] = "deprecated" if options[:deprecated] == "true"

--- a/lib/brightbox-cli/images.rb
+++ b/lib/brightbox-cli/images.rb
@@ -91,6 +91,7 @@ module Brightbox
       o[:description] = description if description
       o[:licence_name] = licence_name
       o[:size] = virtual_size
+      o[:min_ram] = min_ram
       o
     end
 

--- a/spec/commands/images/register_spec.rb
+++ b/spec/commands/images/register_spec.rb
@@ -6,11 +6,98 @@ describe "brightbox images" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+      stub_client_token_request
+      Brightbox.config.reauthenticate
+    end
+
+    context "without arguments" do
       let(:argv) { %w[images register] }
 
       it "does not error" do
         expect { output }.to_not raise_error
+
+        expect(stderr).to match("ERROR: You must specify the architecture")
+        expect(stdout).to match("")
+      end
+    end
+
+    context "with minimal arguments" do
+      let(:argv) { %w[images register --arch x86_64 --source custom.img] }
+
+      before do
+        expect(Brightbox::Image).to receive(:register)
+          .with(hash_including(
+                  arch: "x86_64",
+                  source: "custom.img"
+                ))
+          .and_call_original
+
+        stub_request(:post, "#{api_url}/1.0/images?account_id=acc-12345")
+          .with(body: /"source":"custom.img"/)
+          .to_return(
+            status: 201,
+            body: {
+              id: "img-12345"
+            }.to_json
+          )
+
+        stub_request(:get, "#{api_url}/1.0/images/img-12345?account_id=acc-12345")
+          .to_return(
+            status: 200,
+            body: {
+              id: "img-12345"
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to match("")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("img-12345")
+      end
+    end
+
+    context "with min-ram argument" do
+      let(:argv) { %w[images register --arch x86_64 --source custom.img --min-ram 2048] }
+
+      before do
+        expect(Brightbox::Image).to receive(:register)
+          .with(hash_including(
+                  arch: "x86_64",
+                  min_ram: 2048,
+                  source: "custom.img"
+                ))
+          .and_call_original
+
+        stub_request(:post, "#{api_url}/1.0/images?account_id=acc-12345")
+          .with(body: /"min_ram":2048/)
+          .to_return(
+            status: 201,
+            body: {
+              id: "img-12345"
+            }.to_json
+          )
+
+        stub_request(:get, "#{api_url}/1.0/images/img-12345?account_id=acc-12345")
+          .to_return(
+            status: 200,
+            body: {
+              id: "img-12345",
+              min_ram: 2048
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to match("")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("img-12345")
       end
     end
   end

--- a/spec/commands/images/show_spec.rb
+++ b/spec/commands/images/show_spec.rb
@@ -1,16 +1,69 @@
 require "spec_helper"
 
-describe "brightbox images" do
+RSpec.describe "brightbox images" do
   describe "show" do
     let(:output) { FauxIO.new { Brightbox.run(argv) } }
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      WebMock.reset!
+
+      config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+      stub_client_token_request
+      Brightbox.config.reauthenticate
+    end
+
+    context "without arguments" do
       let(:argv) { %w[images show] }
+
+      before do
+        stub_request(:get, "#{api_url}/1.0/images?account_id=acc-12345")
+          .to_return(
+            status: 200,
+            body: [
+              {
+                id: "img-12345"
+              }
+            ].to_json
+          )
+      end
 
       it "does not error" do
         expect { output }.to_not raise_error
+
+        expect(stderr).to match("")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("img-12345")
+      end
+    end
+
+    context "with identifier" do
+      let(:argv) { %w[images show img-11111] }
+
+      before do
+        expect(Brightbox::Image).to receive(:find)
+          .with("img-11111")
+          .and_call_original
+
+        stub_request(:get, "#{api_url}/1.0/images/img-11111?account_id=acc-12345")
+          .to_return(
+            status: 200,
+            body: {
+              id: "img-11111",
+              min_ram: 2_048
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to match("")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("img-11111")
+
+        expect(stdout).to match("min_ram: 2048")
       end
     end
   end

--- a/spec/commands/images/update_spec.rb
+++ b/spec/commands/images/update_spec.rb
@@ -6,11 +6,62 @@ describe "brightbox images" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+      stub_client_token_request
+      Brightbox.config.reauthenticate
+    end
+
+    context "without arguments" do
       let(:argv) { %w[images update] }
 
       it "does not error" do
         expect { output }.to_not raise_error
+
+        expect(stderr).to match("ERROR: You must specify the image to update as the first argument")
+        expect(stdout).to match("")
+      end
+    end
+
+    context "with --min-ram" do
+      let(:argv) { %w[images update --min-ram 2048 img-12345] }
+
+      before do
+        expect(Brightbox::Image).to receive(:find)
+          .with("img-12345")
+          .and_call_original
+
+        stub_request(:get, "#{api_url}/1.0/images/img-12345?account_id=acc-12345")
+          .and_return(
+            status: 200,
+            body: {
+              id: "img-12345",
+              min_ram: 1_024
+            }.to_json
+          )
+
+        stub_request(:put, "#{api_url}/1.0/images/img-12345?account_id=acc-12345")
+          .with(body: hash_including(
+            min_ram: 2_048
+          ))
+          .and_return(
+            status: 200,
+            body: {
+              id: "img-12345",
+              min_ram: 2_048
+            }.to_json
+          )
+      end
+
+      it "updates min_ram" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to match("")
+        expect(stderr).not_to match("ERROR")
+        expect(stdout).to match("img-12345")
+
+        # No shown in output
+        # expect(stdout).to match("min_ram: 2048")
       end
     end
   end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,4 +1,15 @@
 module AuthenticationHelpers
+  def api_url
+    "http://api.brightbox.localhost"
+  end
+
+  def stub_client_token_request
+    stub_request(:post, "http://api.brightbox.localhost/token").to_return(
+      :status => 200,
+      :body => '{"access_token":"44320b29286077c44f14c4efdfed70f63f4a8361","token_type":"Bearer","refresh_token":"759b2b28c228948a0ba5d07a89f39f9e268a95c0","scope":"infrastructure orbit","expires_in":7200}'
+    )
+  end
+
   def stub_token_request(two_factor: false)
     auth_response = {
       status: 200,


### PR DESCRIPTION
This allows passing an `min-ram` argument that can be used to mark an
image as requiring a minimum amount of RAM so creating a server from too
small a type will report an error.

Rather than an instance building and failing at some point as it runs
out of memory at some point.