### PR TITLE
Pin `dry-inflector` to support Ruby 2.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (4.0.0.rc1)
+      dry-inflector (~> 0.2.0)
       fog-brightbox (>= 1.6.0)
       fog-core (< 2.0)
       gli (~> 2.21.0)
@@ -23,7 +24,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    dry-inflector (0.2.0)
+    dry-inflector (0.2.1)
     excon (0.92.4)
     fog-brightbox (1.6.0)
       dry-inflector

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (4.0.0.rc1)
-      dry-inflector (~> 0.2.0)
+      dry-inflector (= 0.2.0)
       fog-brightbox (>= 1.6.0)
       fog-core (< 2.0)
       gli (~> 2.21.0)
@@ -24,7 +24,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    dry-inflector (0.2.1)
+    dry-inflector (0.2.0)
     excon (0.92.4)
     fog-brightbox (1.6.0)
       dry-inflector

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "fog-brightbox", ">= 1.6.0"
-  s.add_dependency "dry-inflector", "~> 0.2.0" # 0.3 drops support Ruby < 2.7
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21.0"
   s.add_dependency "highline", "~> 1.6.0"
@@ -29,6 +28,11 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", ">= 0.6", "< 1.11"
   s.add_dependency "mime-types", "~> 2.6"
   s.add_dependency "multi_json", "~> 1.11.0"
+
+  # Indirect dependency
+  # 0.3 drops support for Ruby < 2.7
+  # 0.2.1 drops support for Ruby < 2.6
+  s.add_dependency "dry-inflector", "= 0.2.0"
 
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-remote"

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "fog-brightbox", ">= 1.6.0"
+  s.add_dependency "dry-inflector", "~> 0.2.0" # 0.3 drops support Ruby < 2.7
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21.0"
   s.add_dependency "highline", "~> 1.6.0"


### PR DESCRIPTION
`dry-inflector v0.3` drops support for Ruby 2.5 and 2.6 which means
updating other resources can pull in an incompatible dependency for the
older versions we support.

This pins to the 0.2 series.