### PR TITLE
Update `fog-brightbox` to `v1.7.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (4.0.0.rc1)
       dry-inflector (= 0.2.0)
-      fog-brightbox (>= 1.6.0)
+      fog-brightbox (>= 1.7.0)
       fog-core (< 2.0)
       gli (~> 2.21.0)
       highline (~> 1.6.0)
@@ -26,7 +26,7 @@ GEM
     diff-lcs (1.5.0)
     dry-inflector (0.2.0)
     excon (0.92.4)
-    fog-brightbox (1.6.0)
+    fog-brightbox (1.7.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.6.0"
+  s.add_dependency "fog-brightbox", ">= 1.7.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21.0"
   s.add_dependency "highline", "~> 1.6.0"


### PR DESCRIPTION
This adds support for `ConfigMap` resources and updates to include the
attributes currently available in the API.