### PR TITLE
Update jenkinsfile to fix changes made by v4.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
             }
           }
           steps {
+            sh 'gem install bundler:2.1.4'
             sh 'bundle install --deployment'
             sh 'bundle exec rake spec'
           }
@@ -27,6 +28,7 @@ pipeline {
             }
           }
           steps {
+            sh 'gem install bundler:2.1.4'
             sh 'bundle install --deployment'
             sh 'bundle exec rake spec'
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,61 +9,6 @@ pipeline {
   stages {
     stage("Run tests") {
       parallel {
-        stage("Ruby 2.0") {
-          agent {
-            docker {
-              image 'ruby:2.0'
-            }
-          }
-          steps {
-            sh 'bundle install --deployment'
-            sh 'bundle exec rake spec'
-          }
-        }
-        stage("Ruby 2.1") {
-          agent {
-            docker {
-              image 'ruby:2.1'
-            }
-          }
-          steps {
-            sh 'bundle install --deployment'
-            sh 'bundle exec rake spec'
-          }
-        }
-        stage("Ruby 2.2") {
-          agent {
-            docker {
-              image 'ruby:2.2'
-            }
-          }
-          steps {
-            sh 'bundle install --deployment'
-            sh 'bundle exec rake spec'
-          }
-        }
-        stage("Ruby 2.3") {
-          agent {
-            docker {
-              image 'ruby:2.3'
-            }
-          }
-          steps {
-            sh 'bundle install --deployment'
-            sh 'bundle exec rake spec'
-          }
-        }
-        stage("Ruby 2.4") {
-          agent {
-            docker {
-              image 'ruby:2.4'
-            }
-          }
-          steps {
-            sh 'bundle install --deployment'
-            sh 'bundle exec rake spec'
-          }
-        }
         stage("Ruby 2.5") {
           agent {
             docker {
@@ -79,6 +24,39 @@ pipeline {
           agent {
             docker {
               image 'ruby:2.6'
+            }
+          }
+          steps {
+            sh 'bundle install --deployment'
+            sh 'bundle exec rake spec'
+          }
+        }
+        stage("Ruby 2.7") {
+          agent {
+            docker {
+              image 'ruby:2.7'
+            }
+          }
+          steps {
+            sh 'bundle install --deployment'
+            sh 'bundle exec rake spec'
+          }
+        }
+        stage("Ruby 3.0") {
+          agent {
+            docker {
+              image 'ruby:3.0'
+            }
+          }
+          steps {
+            sh 'bundle install --deployment'
+            sh 'bundle exec rake spec'
+          }
+        }
+        stage("Ruby 3.1") {
+          agent {
+            docker {
+              image 'ruby:3.1'
             }
           }
           steps {


### PR DESCRIPTION
Our internal CI setup had unsupported versions of Ruby running
and some of the cached images had too old version of `bundle`.

These changes fix that and bring it in line with GitHub actions.