### PR TITLE
Bump `mime-types` to v3.4.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       highline (~> 1.6.0)
       hirb (~> 0.6)
       i18n (>= 0.6, < 1.11)
-      mime-types (~> 2.6)
+      mime-types (~> 3.0)
       multi_json (~> 1.11.0)
 
 GEM
@@ -45,7 +45,9 @@ GEM
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    mime-types (2.99.3)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mocha (1.14.0)
     multi_json (1.11.3)
     parallel (1.22.1)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "highline", "~> 1.6.0"
   s.add_dependency "hirb", "~> 0.6"
   s.add_dependency "i18n", ">= 0.6", "< 1.11"
-  s.add_dependency "mime-types", "~> 2.6"
+  s.add_dependency "mime-types", "~> 3.0"
   s.add_dependency "multi_json", "~> 1.11.0"
 
   # Indirect dependency


### PR DESCRIPTION
Under Ruby 2.7, deprecation warnings could appear due to `mime-types`
using numbered parameters (`_1`) internally and them now becoming
reserved.

This relaxes the dependency to pick up a later, fixed version to avoid
cluttering the output.