### PR TITLE
Fix empty server groups during `servers create`

### DIFF
--- a/lib/brightbox-cli/commands/servers/create.rb
+++ b/lib/brightbox-cli/commands/servers/create.rb
@@ -114,10 +114,10 @@ module Brightbox
           :flavor_id => type.id,
           :zone_id => zone.to_s,
           :name => options[:n],
-          :user_data => user_data,
-          :server_groups => server_groups.map(&:id)
+          :user_data => user_data
         }
 
+        params[:server_groups] = server_groups.map(&:id) if server_groups.any?
         params[:cloud_ip] = options[:"cloud-ip"] if options.key?(:"cloud-ip")
         params[:disk_encrypted] = options[:"disk-encrypted"] if options.key?(:"disk-encrypted")
 


### PR DESCRIPTION
The API does not accept empty arrays of groups as each server must be
assigned to a group. A server side workaround has been in place to
account for this long standing bug where the unset `server-groups` flag
would report an empty array.

The workaround strips out empty lists and uses the default group which
is the expected behaviour. The newer API documentation had to be
reported incorrectly to account for the workaround.