### PR TITLE
Add `volume-size` flag to `servers create`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (4.0.0)
       dry-inflector (= 0.2.0)
-      fog-brightbox (>= 1.7.0)
+      fog-brightbox (>= 1.8.0)
       fog-core (< 2.0)
       gli (~> 2.21)
       highline (~> 1.6)
@@ -26,7 +26,7 @@ GEM
     diff-lcs (1.5.0)
     dry-inflector (0.2.0)
     excon (0.92.4)
-    fog-brightbox (1.7.3)
+    fog-brightbox (1.8.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.7.0"
+  s.add_dependency "fog-brightbox", ">= 1.8.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21"
   s.add_dependency "highline", "~> 1.6"

--- a/lib/brightbox-cli/commands/servers/create.rb
+++ b/lib/brightbox-cli/commands/servers/create.rb
@@ -37,6 +37,9 @@ module Brightbox
       c.desc I18n.t("servers.create.cloud_ip.desc")
       c.flag ["cloud-ip"]
 
+      c.desc I18n.t("servers.create.volume_size.desc")
+      c.flag ["volume-size"]
+
       c.action do |global_options, options, args|
         if args.empty?
           raise "You must specify the image_id as the first argument"
@@ -120,6 +123,10 @@ module Brightbox
         params[:server_groups] = server_groups.map(&:id) if server_groups.any?
         params[:cloud_ip] = options[:"cloud-ip"] if options.key?(:"cloud-ip")
         params[:disk_encrypted] = options[:"disk-encrypted"] if options.key?(:"disk-encrypted")
+
+        if options.key?(:"volume-size") && !options[:"volume-size"].nil?
+          params[:volume_size] = options[:"volume-size"].to_i
+        end
 
         servers = Server.create_servers options[:i], params
         render_table(servers, global_options)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -144,6 +144,8 @@ en:
       desc: Create servers
       cloud_ip:
         desc: Immediately map a Cloud IP to new server? Either "true" or the identifier of the Cloud IP
+      volume_size:
+        desc: Specify a custom volume size (in MiB) when building a network block storage server
     destroy:
       desc: Destroy servers
     lock:


### PR DESCRIPTION
This allows passing of an arbitary size for the network block storage
volume when using a "nbs" server type.