### PR TITLE
Fix login

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ PATH
       fog-brightbox (>= 1.8.0)
       fog-core (< 2.0)
       gli (~> 2.21)
-      highline (~> 1.6)
+      highline (~> 2.0)
       hirb (~> 0.6)
       i18n (>= 0.6, < 1.11)
       mime-types (~> 3.0)
@@ -40,7 +40,7 @@ GEM
     formatador (0.3.0)
     gli (2.21.0)
     hashdiff (1.0.1)
-    highline (1.7.10)
+    highline (2.0.3)
     hirb (0.7.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -117,4 +117,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.2.33

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "fog-brightbox", ">= 1.8.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21"
-  s.add_dependency "highline", "~> 1.6"
+  s.add_dependency "highline", "~> 2.0"
   s.add_dependency "hirb", "~> 0.6"
   s.add_dependency "i18n", ">= 0.6", "< 1.11"
   s.add_dependency "mime-types", "~> 3.0"

--- a/lib/brightbox-cli/commands/login.rb
+++ b/lib/brightbox-cli/commands/login.rb
@@ -1,13 +1,12 @@
 module Brightbox
+  desc I18n.t("login.desc")
+  arg :email
   command [:login] do |cmd|
-    cmd.desc I18n.t("login.desc")
-    cmd.arg_name "email"
-
     cmd.desc "password, if not specified you will be prompted"
-    cmd.flag [:p, "password"]
+    cmd.flag [:p, "password"], arg_name: "password"
 
-    cmd.desc "default account"
-    cmd.flag [:"default-account"]
+    cmd.desc "Set a default account"
+    cmd.flag [:"default-account"], arg_name: "acc-12345"
 
     cmd.flag [:"application-id"]
     cmd.flag [:"application-secret"]

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -136,6 +136,8 @@ en:
     update:
       desc: Update a load balancer
       long_desc: All intervals and timeouts are in milliseconds
+  login:
+    desc: Authenticate using an email address
   servers:
     desc: Manage an account's servers
     activate_console:


### PR DESCRIPTION
Ruby 3.0+ was reporting problems when prompting for password during the `login` due to an older version of `highline` being declared in the `gemspec`.

The `login` command was also incorrectly documented so the `--help` output was missing a description, main argument and incorrectly tied the password to the email.