### PR TITLE
Add `Volume` management commands

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (4.2.1)
       dry-inflector (= 0.2.0)
-      fog-brightbox (>= 1.8.0)
+      fog-brightbox (>= 1.9.1)
       fog-core (< 2.0)
       gli (~> 2.21)
       highline (~> 2.0)
@@ -25,8 +25,8 @@ GEM
       rexml
     diff-lcs (1.5.0)
     dry-inflector (0.2.0)
-    excon (0.94.0)
-    fog-brightbox (1.8.0)
+    excon (0.97.0)
+    fog-brightbox (1.9.1)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.8.0"
+  s.add_dependency "fog-brightbox", ">= 1.9.1"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21"
   s.add_dependency "highline", "~> 2.0"

--- a/lib/brightbox-cli/commands/volumes/attach.rb
+++ b/lib/brightbox-cli/commands/volumes/attach.rb
@@ -1,0 +1,36 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.attach.desc")
+    cmd.arg_name I18n.t("volumes.attach.args")
+
+    cmd.command [:attach] do |c|
+      c.desc I18n.t("volumes.options.boot")
+      c.default_value false
+      c.switch [:boot], negatable: true
+
+      c.action do |global_options, options, args|
+        vol_id = args.shift
+
+        if vol_id.nil? || !vol_id.start_with?("vol-")
+          raise I18n.t("volumes.args.specify_one_id_first")
+        end
+
+        srv_id = args.shift
+
+        if srv_id.nil? || !srv_id.start_with?("srv-")
+          raise I18n.t("volumes.attach.specify_server_id_second")
+        end
+
+        boot_flag = options[:boot]
+
+        volume = Volume.find(vol_id)
+
+        info I18n.t("volumes.attach.acting", volume: volume)
+        volume.attach(server: srv_id, boot: boot_flag)
+        volume.reload
+
+        render_table([volume], global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/copy.rb
+++ b/lib/brightbox-cli/commands/volumes/copy.rb
@@ -1,0 +1,45 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.copy.desc")
+    cmd.arg_name I18n.t("volumes.args.one")
+
+    cmd.command [:copy] do |c|
+      c.desc I18n.t("options.description.desc")
+      c.flag %i[d description]
+
+      c.desc I18n.t("volumes.options.delete_with_server")
+      c.default_value false
+      c.switch ["delete-with-server"], negatable: true
+
+      c.desc I18n.t("options.name.desc")
+      c.flag %i[n name]
+
+      c.desc I18n.t("volumes.options.serial")
+      c.flag [:serial]
+
+      c.action do |global_options, options, args|
+        vol_id = args.shift
+
+        if vol_id.nil? || !vol_id.start_with?("vol-")
+          raise I18n.t("volumes.args.specify_one_id_first")
+        end
+
+        params = {
+          delete_with_server: options["delete-with-server"]
+        }
+        params[:description] = options[:description] if options[:description]
+        params[:name] = options[:name] if options[:name]
+        params[:serial] = options[:serial] if options[:serial]
+
+        volume = Volume.find(vol_id)
+
+        unless params.empty?
+          info I18n.t("volumes.copy.acting", volume: volume)
+          volume.copy(params)
+        end
+
+        render_table([volume], global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/create.rb
+++ b/lib/brightbox-cli/commands/volumes/create.rb
@@ -1,0 +1,63 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.create.desc")
+
+    cmd.command [:create] do |c|
+      c.desc I18n.t("options.description.desc")
+      c.flag %i[d description]
+
+      c.desc I18n.t("volumes.options.delete_with_server")
+      c.default_value false
+      c.switch ["delete-with-server"], negatable: true
+
+      c.desc I18n.t("volumes.options.encrypted")
+      c.switch %i[e encrypted], negatable: true
+
+      c.desc I18n.t("volumes.options.fs_label")
+      c.flag ["fs-label"]
+
+      c.desc I18n.t("volumes.options.fs_type")
+      c.flag ["fs-type"]
+
+      c.desc I18n.t("volumes.options.image")
+      c.flag %i[i image]
+
+      c.desc I18n.t("options.name.desc")
+      c.flag %i[n name]
+
+      c.desc I18n.t("volumes.options.serial")
+      c.flag [:serial]
+
+      c.desc I18n.t("volumes.options.size")
+      c.flag %i[s size]
+
+      c.action do |global_options, options, _args|
+        if options[:image].nil? && options[:"fs-type"].nil?
+          raise I18n.t("volumes.create.image_or_type_required")
+        end
+
+        if !options[:image].nil? && !options[:"fs-type"].nil?
+          raise I18n.t("volumes.create.either_image_or_type")
+        end
+
+        params = {
+          delete_with_server: options[:"delete-with-server"],
+          encrypted: options[:encrypted]
+        }
+
+        params[:filesystem_label] = options[:"fs-label"] if options[:"fs-label"]
+        params[:filesystem_type] = options[:"fs-type"] if options[:"fs-type"]
+        params[:image_id] = options[:image] if options[:image]
+
+        params[:description] = options[:description] if options[:description]
+        params[:name] = options[:name] if options[:name]
+        params[:serial] = options[:serial] if options[:serial]
+        params[:size] = options[:size] if options[:size]
+
+        info I18n.t("volumes.create.acting")
+        volume = Volume.create(params)
+        render_table([volume], global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/destroy.rb
+++ b/lib/brightbox-cli/commands/volumes/destroy.rb
@@ -1,0 +1,26 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.destroy.desc")
+    cmd.arg_name I18n.t("volumes.args.many")
+
+    cmd.command [:destroy] do |c|
+      c.action do |_global_options, _options, args|
+        raise I18n.t("volumes.args.specify_many_ids") if args.empty?
+
+        volumes = Volume.find_or_call(args) do |id|
+          raise I18n.t("volumes.args.unknown_id", volume: volume)
+        end
+
+        volumes.each do |volume|
+          info I18n.t("volumes.destroy.acting", volume: volume)
+
+          begin
+            volume.destroy
+          rescue Brightbox::Api::Conflict
+            error "Could not destroy #{id}"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/detach.rb
+++ b/lib/brightbox-cli/commands/volumes/detach.rb
@@ -1,0 +1,23 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.detach.desc")
+    cmd.arg_name I18n.t("volumes.args.many")
+
+    cmd.command [:detach] do |c|
+      c.action do |global_options, _options, args|
+        raise I18n.t("volumes.args.specify_many_ids") if args.empty?
+
+        volumes = Volume.find_or_call(args) do |volume|
+          raise I18n.t("volumes.args.unknown_id", volume: volume)
+        end
+
+        volumes.each do |volume|
+          info I18n.t("volumes.detach.acting", volume: volume)
+          volume.detach
+        end
+
+        render_table(volumes, global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/list.rb
+++ b/lib/brightbox-cli/commands/volumes/list.rb
@@ -1,0 +1,16 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.default_command :list
+
+    cmd.desc I18n.t("volumes.list.desc")
+    cmd.arg_name I18n.t("volumes.args.optional")
+
+    cmd.command [:list] do |c|
+      c.action do |global_options, _options, args|
+        volumes = Volume.find_all_or_warn(args)
+
+        render_table(volumes, global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/locking.rb
+++ b/lib/brightbox-cli/commands/volumes/locking.rb
@@ -1,0 +1,39 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.lock.desc")
+    cmd.arg_name I18n.t("volumes.args.many")
+
+    cmd.command [:lock] do |c|
+      c.action do |_global_options, _options, args|
+        raise I18n.t("volumes.args.specify_many_ids") if args.empty?
+
+        volumes = Volume.find_or_call(args) do |volume|
+          raise I18n.t("volumes.args.unknown_id", volume: volume)
+        end
+
+        volumes.each do |volume|
+          info I18n.t("volumes.lock.acting", volume: volume)
+          volume.lock!
+        end
+      end
+    end
+
+    cmd.desc I18n.t("volumes.unlock.desc")
+    cmd.arg_name I18n.t("volumes.args.many")
+
+    cmd.command [:unlock] do |c|
+      c.action do |_global_options, _options, args|
+        raise I18n.t("volumes.args.specify_many_ids") if args.empty?
+
+        volumes = Volume.find_or_call(args) do |volume|
+          raise I18n.t("volumes.args.unknown_id", volume: volume)
+        end
+
+        volumes.each do |volume|
+          info I18n.t("volumes.unlock.acting", volume: volume)
+          volume.unlock!
+        end
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/resize.rb
+++ b/lib/brightbox-cli/commands/volumes/resize.rb
@@ -1,0 +1,36 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.resize.desc")
+    cmd.arg_name I18n.t("volumes.args.one")
+
+    cmd.command [:resize] do |c|
+      c.desc I18n.t("volumes.options.size")
+      c.flag %i[s size]
+
+      c.action do |global_options, options, args|
+        vol_id = args.shift
+
+        if vol_id.nil? || !vol_id.start_with?("vol-")
+          raise I18n.t("volumes.args.specify_one_id_first")
+        end
+
+        if options[:size].nil?
+          raise I18n.t("volumes.resize.size_option_needed")
+        end
+
+        new_size = options[:size].to_i
+
+        volume = Volume.find(vol_id)
+        old_size = volume.size
+
+        info I18n.t("volumes.resize.acting", volume: volume)
+        volume.resize(
+          from: old_size,
+          to: new_size
+        )
+
+        render_table([volume], global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/show.rb
+++ b/lib/brightbox-cli/commands/volumes/show.rb
@@ -1,0 +1,18 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.show.desc")
+    cmd.arg_name I18n.t("volumes.args.optional")
+
+    cmd.command [:show] do |c|
+      c.action do |global_options, _options, args|
+        volumes = Volume.find_all_or_warn(args)
+
+        table_opts = global_options.merge(
+          :vertical => true,
+          :fields => Volume.detailed_fields
+        )
+        render_table(volumes, table_opts)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/volumes/update.rb
+++ b/lib/brightbox-cli/commands/volumes/update.rb
@@ -1,0 +1,50 @@
+module Brightbox
+  command [:volumes] do |cmd|
+    cmd.desc I18n.t("volumes.update.desc")
+    cmd.arg_name I18n.t("volumes.args.one")
+
+    cmd.command [:update] do |c|
+      c.desc I18n.t("options.description.desc")
+      c.flag %i[d description]
+
+      c.desc I18n.t("volumes.options.delete_with_server")
+      c.default_value :ignore # So we can discard unless deliberately passed
+      c.switch ["delete-with-server"], negatable: true
+
+      c.desc I18n.t("options.name.desc")
+      c.flag %i[n name]
+
+      c.desc I18n.t("volumes.options.serial")
+      c.flag [:serial]
+
+      c.action do |global_options, options, args|
+        vol_id = args.shift
+
+        if vol_id.nil? || !vol_id.start_with?("vol-")
+          raise I18n.t("volumes.args.specify_one_id_first")
+        end
+
+        params = {}
+
+        # Switches will always appear in the options so we need a non-boolean
+        # setting to determine if the user did not add it to their command
+        unless options["delete-with-server"] == :ignore
+          params[:delete_with_server] = options["delete-with-server"]
+        end
+
+        params[:description] = options[:description] if options[:description]
+        params[:name] = options[:name] if options[:name]
+        params[:serial] = options[:serial] if options[:serial]
+
+        volume = Volume.find(vol_id)
+
+        unless params.empty?
+          info I18n.t("volumes.update.acting", volume: volume)
+          volume.update(params)
+        end
+
+        render_table([volume], global_options)
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/detailed_server.rb
+++ b/lib/brightbox-cli/detailed_server.rb
@@ -31,7 +31,19 @@ module Brightbox
         row_attributes[:server_groups] = server_groups.map { |sg| sg["id"] }.join(", ")
       end
 
+      row_attributes[:volumes] = volume_ids if volumes
+
       row_attributes
+    end
+
+    def volume_ids
+      volumes.map do |vol|
+        if vol["boot"] == true
+          "*#{vol['id']}*"
+        else
+          vol["id"]
+        end
+      end.join(", ")
     end
 
     def self.default_field_order
@@ -65,6 +77,7 @@ module Brightbox
         cloud_ipv6s
         snapshots
         server_groups
+        volumes
       ]
     end
   end

--- a/lib/brightbox-cli/volume.rb
+++ b/lib/brightbox-cli/volume.rb
@@ -1,0 +1,81 @@
+module Brightbox
+  class Volume < Api
+    def self.require_account?; true; end
+
+    def self.all
+      conn.volumes
+    end
+
+    def self.create(options)
+      new(conn.volumes.create(options))
+    end
+
+    def self.get(id)
+      conn.volumes.get(id)
+    end
+
+    def self.default_field_order
+      %i[
+        id
+        type
+        size
+        status
+        server
+        boot
+        name
+      ]
+    end
+
+    def self.detailed_fields
+      %i[
+        id
+        name
+        description
+        type
+        size
+        status
+        created_at
+        encrypted
+        serial
+        locked
+        filesystem_label
+        filesystem_type
+        image
+        source
+        source_type
+        server
+        boot
+        delete_with_server
+        zone
+      ]
+    end
+
+    def attach(server:, boot: false)
+      self.class.conn.attach_volume(id, server: server, boot: boot)
+      reload
+      self
+    end
+
+    def attributes
+      a = fog_model.attributes
+      a[:id] = fog_model.id
+      a[:image] = image_id
+      a[:locked] = locked?
+      a[:server] = server_id
+      a[:status] = state
+      a[:type] = storage_type
+      a[:zone] = zone_id
+      a
+    end
+
+    def to_row
+      attributes
+    end
+
+    def update(options)
+      self.class.conn.update_volume(id, options)
+      reload
+      self
+    end
+  end
+end

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -56,6 +56,7 @@ module Brightbox
   autoload :DatabaseType, File.expand_path("brightbox-cli/database_type", __dir__)
   autoload :DatabaseServer, File.expand_path("brightbox-cli/database_server", __dir__)
   autoload :DatabaseSnapshot, File.expand_path("brightbox-cli/database_snapshot", __dir__)
+  autoload :Volume, File.expand_path("brightbox-cli/volume", __dir__)
   autoload :Token, File.expand_path("brightbox-cli/token", __dir__)
 
   module Config

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -155,7 +155,7 @@ en:
     reboot:
       desc: Reboot servers (OS reboot issued)
     reset:
-      desc: Reset servers (Hardward reset issued)
+      desc: Reset servers (Hardware reset issued)
     show:
       desc: Show servers
     shutdown:
@@ -245,3 +245,59 @@ en:
       desc: Show users
     update:
       desc: Update a user
+  volumes:
+    desc: Manage an account's volumes
+    args:
+      one: <volume>
+      optional: [<volume>...]
+      many: <volume>...
+      specify_one_id_first: You must specify the volume ID as the first argument
+      specify_many_ids: You must specify volume IDs as arguments
+      unknown_id: Couldn't find %{volume}
+    options:
+      boot: Set this volume as boot volume on server
+      delete_with_server: Set volume to be deleted with a server if attached
+      encrypted: Encrypt the volume
+      fs_label: Filesystem label, visible from within some OS
+      fs_type: Filesystem type to use to create blank volume
+      image: Create volume from existing Image ID
+      serial: Customisable serial number for volume
+      size: Volume size in MB
+    attach:
+      desc: Attach a volume to an existing server
+      args: <volume> <server>
+      specify_server_id_second: "You must specify the server ID to attach to as the second argument"
+      acting: Attaching %{volume}
+    copy:
+      desc: Create a new volume from an existing one
+      acting: Copying %{volume}
+    create:
+      desc: Create a new volume
+      acting: Creating volume
+      image_or_type_required: An 'image' or 'fs-type' option must be passed
+      either_image_or_type: An 'image' and 'fs-type' can not be passed together
+    destroy:
+      desc: Destroy one or more volumes
+      acting: Destroying %{volume}
+    detach:
+      desc: Detach a volume from a server
+      acting: Detaching %{volume}
+    list:
+      desc: List all volumes or limit using passed IDs
+    lock:
+      desc: Lock volumes
+      acting: Locking %{volume}
+    resize:
+      desc: Resize a volume
+      size_option_needed: A 'size' option is required
+      acting: Resizing %{volume}
+    show:
+      desc: Show details about multiple volumes
+    unlock:
+      desc: Unlock volumes
+      acting: Unlocking %{volume}
+    update:
+      desc: Update a volume
+      acting: Updating %{volume}
+
+

--- a/spec/commands/volumes/attach_spec.rb
+++ b/spec/commands/volumes/attach_spec.rb
@@ -1,0 +1,165 @@
+require "spec_helper"
+
+describe "brightbox volumes attach" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes attach] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify the volume ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "without server arguments" do
+    let(:argv) { %w[volumes attach vol-32145] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify the server ID to attach to as the second argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with arguments" do
+    let(:argv) { %w[volumes attach vol-809s1 srv-03431] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-809s1")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-809s1",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-809s1",
+            status: "attached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-809s1/attach")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: hash_including(
+                server: "srv-03431",
+                boot: false
+              ))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-809s1",
+            status: "attached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Attaching vol-809s1\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-809s1")
+        expect(stdout).to match("attached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+
+  context "with boot option" do
+    let(:argv) { %w[volumes attach --boot vol-90328 srv-03431] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-90328")
+      .with(query: hash_including(account_id: "acc-12345"))
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-90328",
+          status: "detached",
+          boot: false,
+          server: nil
+        )
+      )
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-90328",
+          status: "attached",
+          boot: true,
+          server: {
+            id: "srv-03431"
+          }
+        )
+      )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-90328/attach")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: hash_including(
+                server: "srv-03431",
+                boot: true
+              ))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-90328",
+            boot: true,
+            status: "attached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Attaching vol-90328\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-90328")
+        expect(stdout).to match("attached")
+        expect(stdout).to match("true")
+      end
+    end
+  end
+end

--- a/spec/commands/volumes/copy_spec.rb
+++ b/spec/commands/volumes/copy_spec.rb
@@ -1,0 +1,74 @@
+require "spec_helper"
+
+describe "brightbox volumes copy" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes copy] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify the volume ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with argument" do
+    let(:argv) { %w[volumes copy vol-909ds] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-909ds")
+      .with(query: hash_including(account_id: "acc-12345"))
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-909ds"
+        )
+      )
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-909ds"
+        )
+      )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-909ds/copy")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-909ds"
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Copying vol-909ds\n")
+
+      expect(stdout).to match("vol-909ds")
+    end
+  end
+end

--- a/spec/commands/volumes/create_spec.rb
+++ b/spec/commands/volumes/create_spec.rb
@@ -1,0 +1,217 @@
+require "spec_helper"
+
+describe "brightbox volumes create" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  let(:token) { SecureRandom.hex }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(status: 200, body: JSON.dump(access_token: token))
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without options" do
+    let(:argv) { %w[volumes create] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("ERROR: An 'image' or 'fs-type' option must be passed")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with mutually exclusive options" do
+    let(:argv) { %w[volumes create --image img-12345 --fs-type ext4] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("ERROR: An 'image' and 'fs-type' can not be passed together")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with image identifier" do
+    let(:argv) { %w[volumes create --image img-12345] }
+
+    before do
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes")
+        .with(headers: { "Content-Type" => "application/json" },
+              query: hash_including(account_id: "acc-12345"),
+              body: {
+                delete_with_server: false,
+                encrypted: false,
+                image: "img-12345"
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-12345",
+            storage_type: "network",
+            size: 10_240,
+            status: "detached"
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*type.*size.*status.*server.*boot")
+
+        expect(stdout).to match("vol-12345")
+        expect(stdout).to match("network")
+        expect(stdout).to match("10240")
+        expect(stdout).to match("detached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+
+  context "with image and size" do
+    let(:argv) { %w[volumes create --image img-12345 --size 20480] }
+
+    before do
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes")
+        .with(headers: { "Content-Type" => "application/json" },
+              query: hash_including(account_id: "acc-12345"),
+              body: {
+                delete_with_server: false,
+                encrypted: false,
+                image: "img-12345",
+                size: 20_480
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-12345",
+            storage_type: "network",
+            size: 20_480,
+            status: "detached"
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*type.*size.*status.*server.*boot")
+
+        expect(stdout).to match("vol-12345")
+        expect(stdout).to match("network")
+        expect(stdout).to match("20480")
+        expect(stdout).to match("detached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+
+  context "with filesystem type" do
+    let(:argv) { %w[volumes create --fs-type ext4] }
+
+    before do
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes")
+        .with(headers: { "Content-Type" => "application/json" },
+              query: hash_including(account_id: "acc-12345"),
+              body: {
+                delete_with_server: false,
+                encrypted: false,
+                filesystem_type: "ext4"
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-12345",
+            storage_type: "network",
+            size: 10_240,
+            status: "detached"
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*type.*size.*status.*server.*boot")
+
+        expect(stdout).to match("vol-12345")
+        expect(stdout).to match("network")
+        expect(stdout).to match("10240")
+        expect(stdout).to match("detached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+
+  context "with most options" do
+          let(:argv) do
+            %w[volumes create --fs-label fnord --fs-type ext4 --delete-with-server --encrypted --name Nom -d Test --serial 12345 -s 20480]
+          end
+
+    before do
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes")
+        .with(headers: { "Content-Type" => "application/json" },
+              query: hash_including(account_id: "acc-12345"),
+              body: {
+                delete_with_server: true,
+                description: "Test",
+                encrypted: true,
+                filesystem_label: "fnord",
+                filesystem_type: "ext4",
+                name: "Nom",
+                serial: "12345",
+                size: 20_480
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-43251",
+            name: "Nom",
+            boot: false,
+            description: "Test",
+            encrypted: true,
+            serial: "12345",
+            storage_type: "network",
+            size: 20_480,
+            status: "detached"
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*type.*size.*status.*server.*boot")
+
+        expect(stdout).to match("vol-43251")
+        expect(stdout).to match("network")
+        expect(stdout).to match("20480")
+        expect(stdout).to match("detached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+end

--- a/spec/commands/volumes/destroy_spec.rb
+++ b/spec/commands/volumes/destroy_spec.rb
@@ -1,0 +1,173 @@
+require "spec_helper"
+
+describe "brightbox volumes destroy" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes destroy] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify volume IDs as arguments\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with one argument" do
+    let(:argv) { %w[volumes destroy vol-ui342] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-ui342")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-ui342",
+            status: "detached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-ui342",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+
+      stub_request(:delete, "http://api.brightbox.localhost/1.0/volumes/vol-ui342")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-ui342",
+            status: "detached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Destroying vol-ui342\n")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with multiple arguments" do
+    let(:argv) { %w[volumes destroy vol-o2342 vol-3422f] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-o2342")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-o2342",
+            status: "detached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-o2342",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+
+      stub_request(:delete, "http://api.brightbox.localhost/1.0/volumes/vol-o2342")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-o2342",
+            status: "detached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+
+        stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-3422f")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-3422f",
+            status: "detached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-3422f",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+
+      stub_request(:delete, "http://api.brightbox.localhost/1.0/volumes/vol-3422f")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-3422f",
+            status: "detached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Destroying vol-o2342\n")
+      expect(stderr).to match("Destroying vol-3422f\n")
+
+      expect(stdout).to eq("")
+    end
+  end
+end

--- a/spec/commands/volumes/detach_spec.rb
+++ b/spec/commands/volumes/detach_spec.rb
@@ -1,0 +1,180 @@
+require "spec_helper"
+
+describe "brightbox volumes detach" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes detach] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify volume IDs as arguments\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with one argument" do
+    let(:argv) { %w[volumes detach vol-dkl43] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-dkl43")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-dkl43",
+            status: "attached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-dkl43",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-dkl43/detach")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-dkl43",
+            status: "detached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Detaching vol-dkl43\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-dkl43")
+        expect(stdout).to match("detached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+
+  context "with multiple arguments" do
+    let(:argv) { %w[volumes detach vol-p3241 vol-3422f] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-p3241")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-p3241",
+            status: "attached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-p3241",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-p3241/detach")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-p3241",
+            status: "detached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+
+        stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-3422f")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-3422f",
+            status: "attached",
+            boot: false,
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-3422f",
+            status: "detached",
+            boot: false,
+            server: nil
+          )
+        )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-3422f/detach")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-3422f",
+            status: "detached",
+            server: {
+              id: "srv-03431"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Detaching vol-3422f\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-p3241")
+        expect(stdout).to match("detached")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+end

--- a/spec/commands/volumes/list_spec.rb
+++ b/spec/commands/volumes/list_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+describe "brightbox volumes list" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes list] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volumes_response
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*type.*size.*status.*server.*boot")
+
+        expect(stdout).to match("vol-12345")
+        expect(stdout).to match("network")
+        expect(stdout).to match("10240")
+        expect(stdout).to match("attached")
+        expect(stdout).to match("srv-12345")
+        expect(stdout).to match("false")
+
+        expect(stdout).to match("vol-abcde")
+        expect(stdout).to match("network")
+        expect(stdout).to match("10240")
+        expect(stdout).to match("attached")
+        expect(stdout).to match("srv-12345")
+        expect(stdout).to match("true")
+      end
+    end
+  end
+
+  context "with identifier" do
+    let(:argv) { %w[volumes list vol-12345] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-12345")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-12345",
+            storage_type: "network",
+            size: 10_240,
+            status: "attached",
+            server: {
+              id: "srv-12345"
+            }
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*type.*size.*status.*server.*boot")
+
+        expect(stdout).to match("vol-12345")
+        expect(stdout).to match("network")
+        expect(stdout).to match("10240")
+        expect(stdout).to match("attached")
+        expect(stdout).to match("srv-12345")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+end

--- a/spec/commands/volumes/resize_spec.rb
+++ b/spec/commands/volumes/resize_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe "brightbox volumes resize" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes resize] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify the volume ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "without size option" do
+    let(:argv) { %w[volumes resize vol-i89u9] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: A 'size' option is required\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with size option" do
+    let(:argv) { %w[volumes resize --size 20480 vol-op324] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-op324")
+      .with(query: hash_including(account_id: "acc-12345"))
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-op324",
+          size: 10_240
+        )
+      )
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-op324",
+          size: 20_480
+        )
+      )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/volumes/vol-op324/resize")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: hash_including(
+                from: 10_240,
+                to: 20_480
+              ))
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-op324",
+            size: 20_480
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Resizing vol-op324\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-op324")
+        expect(stdout).to match("20480")
+      end
+    end
+  end
+end

--- a/spec/commands/volumes/show_spec.rb
+++ b/spec/commands/volumes/show_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+describe "brightbox volumes show" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes show] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volumes_response
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("")
+
+      aggregate_failures do
+        expect(stdout).to match("id: vol-12345")
+        expect(stdout).to match("id: vol-abcde")
+      end
+    end
+  end
+
+  context "with identifier" do
+    let(:argv) { %w[volumes show vol-88878] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-88878")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-88878",
+            description: "A volume for testing",
+            filesystem_type: "ext4",
+            storage_type: "network",
+            size: 10_240,
+            status: "attached",
+            server: nil
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id: vol-88878")
+        expect(stdout).to match("status: attached")
+        expect(stdout).to match("created_at: 2023-01-01T01:01Z")
+        expect(stdout).to match("description: A volume for testing")
+        expect(stdout).to match("zone: zon-12345")
+        expect(stdout).to match("size: 10240")
+        expect(stdout).to match("type: network")
+        expect(stdout).to match("server:")
+        expect(stdout).to match("boot: false")
+        expect(stdout).to match("filesystem_label:")
+        expect(stdout).to match("filesystem_type: ext4")
+        expect(stdout).to match("delete_with_server: false")
+        expect(stdout).to match("encrypted: false")
+        expect(stdout).to match("serial: vol-12345")
+        expect(stdout).to match("source:")
+        expect(stdout).to match("image: img-12345")
+        expect(stdout).to match("locked: false")
+      end
+    end
+  end
+end

--- a/spec/commands/volumes/update_spec.rb
+++ b/spec/commands/volumes/update_spec.rb
@@ -1,0 +1,188 @@
+require "spec_helper"
+
+describe "brightbox volumes update" do
+  include VolumeHelpers
+
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[volumes update] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify the volume ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with new options" do
+    let(:argv) { %w[volumes update --name New --desc Testing --serial 12345 vol-908us] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-908us")
+      .with(query: hash_including(account_id: "acc-12345"))
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-908us",
+          name: "Old",
+          description: nil,
+          delete_with_server: true,
+          serial: "vol-908us"
+        )
+      )
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-908us",
+          name: "New",
+          description: "Testing",
+          delete_with_server: true,
+          serial: "12345"
+        )
+      )
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/volumes/vol-908us")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: {
+                name: "New",
+                description: "Testing",
+                serial: "12345"
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-908us",
+            name: "New",
+            description: "Testing",
+            delete_with_server: true,
+            serial: "12345"
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating vol-908us\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-908us")
+        expect(stdout).to match("New")
+      end
+    end
+  end
+
+  context "with delete-with-server option" do
+    let(:argv) { %w[volumes update --delete-with-server vol-kl234] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-kl234")
+      .with(query: hash_including(account_id: "acc-12345"))
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-kl234",
+          delete_with_server: false
+        )
+      )
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-kl234",
+          delete_with_server: true
+        )
+      )
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/volumes/vol-kl234")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: {
+                delete_with_server: true
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-kl234",
+            delete_with_server: true
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating vol-kl234\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-kl234")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+
+  context "with no-delete-with-server option" do
+    let(:argv) { %w[volumes update --no-delete-with-server vol-sdj2j] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-sdj2j")
+      .with(query: hash_including(account_id: "acc-12345"))
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-sdj2j",
+          delete_with_server: true
+        )
+      )
+      .to_return(
+        status: 200,
+        body: volume_response(
+          id: "vol-sdj2j",
+          delete_with_server: false
+        )
+      )
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/volumes/vol-sdj2j")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: {
+                delete_with_server: false
+              })
+        .to_return(
+          status: 202,
+          body: volume_response(
+            id: "vol-sdj2j",
+            delete_with_server: false
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating vol-sdj2j\n")
+
+      aggregate_failures do
+        expect(stdout).to match("vol-sdj2j")
+        expect(stdout).to match("false")
+      end
+    end
+  end
+end

--- a/spec/support/volume_helpers.rb
+++ b/spec/support/volume_helpers.rb
@@ -1,0 +1,167 @@
+module VolumeHelpers
+  def volumes_response
+    JSON.dump(
+      [
+        {
+          id: "vol-12345",
+          name: "Second volume",
+          description: nil,
+          boot: false,
+          delete_with_server: false,
+          encrypted: false,
+          filesystem_label: nil,
+          filesystem_type: "ext4",
+          locked: false,
+          serial: "vol-12345",
+          size: 10_240,
+          source: nil,
+          source_type: "raw",
+          status: "attached",
+          storage_type: "network",
+          created_at: "2022-11-09T13:02:10Z",
+          updated_at: "2023-01-05T10:38:42Z",
+          deleted_at: nil,
+          account: {
+            id: "acc-12345",
+            name: "Test account",
+            status: "active"
+          },
+          image: {
+            id: "img-45mb8",
+            name: "Blank Disk Image",
+            username: nil,
+            status: "available",
+            locked: false,
+            description: "",
+            source: "blank-image",
+            source_trigger: "manual",
+            arch: "x86_64",
+            created_at: "2013-05-02T16:40:17.000Z",
+            official: true,
+            public: true,
+            owner: "acc-12345"
+          },
+          server: {
+            id: "srv-12345",
+            name: "Multi volume test",
+            status: "active",
+            locked: false,
+            hostname: "srv-12345",
+            fqdn: "srv-12345.brightbox.localhost",
+            created_at: "2022-11-09T13:04:07.000Z",
+            started_at: "2022-11-09T13:04:50.000Z",
+            deleted_at: nil
+          },
+          zone: {
+            id: "zon-12345",
+            handle: "gb1-a"
+          }
+        },
+        {
+          id: "vol-abcde",
+          name: nil,
+          description: nil,
+          boot: true,
+          delete_with_server: true,
+          encrypted: false,
+          filesystem_label: nil,
+          filesystem_type: nil,
+          locked: false,
+          serial: "vol-abcde",
+          size: 10_240,
+          source: "img-f68lm",
+          source_type: "image",
+          status: "attached",
+          storage_type: "network",
+          created_at: "2022-11-09T13:04:07Z",
+          updated_at: "2023-01-05T10:38:42Z",
+          deleted_at: nil,
+          account: {
+            id: "acc-12345",
+            name: "Test account",
+            status: "active"
+          },
+          image: {
+            id: "img-f68lm",
+            name: "ubuntu-jammy-22.04-amd64-server",
+            username: "ubuntu",
+            status: "deprecated",
+            locked: false,
+            description: "ID: com.ubuntu.cloud:released:download/com.ubuntu.cloud:server:22.04:amd64/20221101.1/disk1.img, Release: release",
+            source: "tmp41_g645e",
+            source_trigger: "manual",
+            arch: "x86_64",
+            created_at: "2022-11-03T07:01:15.000Z",
+            official: true,
+            public: true,
+            owner: "acc-kg71m"
+          },
+          server: {
+            id: "srv-12345",
+            name: "Multi volume test",
+            status: "active",
+            locked: false,
+            hostname: "srv-12345",
+            fqdn: "srv-12345.brightbox.localhost",
+            created_at: "2022-11-09T13:04:07.000Z",
+            started_at: "2022-11-09T13:04:50.000Z",
+            deleted_at: nil
+          },
+          zone: {
+            id: "zon-12345",
+            handle: "gb1-a"
+          }
+        }
+      ]
+    )
+  end
+
+  def volume_response(options)
+    default = {
+      id: "vol-12345",
+      name: SecureRandom.base64,
+      description: SecureRandom.base64,
+      boot: false,
+      delete_with_server: false,
+      encrypted: false,
+      filesystem_label: nil,
+      filesystem_type: "ext4",
+      locked: false,
+      serial: "vol-12345",
+      size: 10_240,
+      source: nil,
+      source_type: "raw",
+      status: "detached",
+      storage_type: "network",
+      created_at: "2023-01-01T01:01:00Z",
+      updated_at: "2023-01-01T01:01:05Z",
+      deleted_at: nil,
+      account: {
+        id: "acc-12345",
+        name: "Test account",
+        status: "active"
+      },
+      image: {
+        id: "img-12345",
+        name: "Blank Disk Image",
+        username: nil,
+        status: "available",
+        locked: false,
+        description: "",
+        source: "blank-image",
+        source_trigger: "manual",
+        arch: "x86_64",
+        created_at: "2013-05-02T16:40:17.000Z",
+        official: true,
+        public: true,
+        owner: "acc-12345"
+      },
+      server: nil,
+      zone: {
+        id: "zon-12345",
+        handle: "gb1-a"
+      }
+    }
+    JSON.dump(default.merge!(options))
+  end
+end


### PR DESCRIPTION
This adds support for `Volume` management with the subcommands:

* `create` - create a new detached network volume
* `list` - returns a summary of all volumes on an account
* `show` - returns details of a given account
* `update` - updates volume attributes
* `destroy` - deletes a detached network volume
* `attach` - attaches volume to a server
* `detach` - detaches a volume from a server
* `resize` - increases the size of a volume
* `copy` - duplicates an existing volume