### PR TITLE
Fix intrusive CLI switch defaults

### DIFF
--- a/lib/brightbox-cli/commands/lbs/update.rb
+++ b/lib/brightbox-cli/commands/lbs/update.rb
@@ -50,7 +50,7 @@ module Brightbox
       c.switch ["remove-ssl"], :negatable => false
 
       c.desc "Enable SSL v3 support"
-      c.switch ["sslv3"]
+      c.switch ["sslv3"], ignore_default: true
 
       c.action do |global_options, options, args|
         lb_id = args.shift

--- a/lib/brightbox-cli/commands/servers/create.rb
+++ b/lib/brightbox-cli/commands/servers/create.rb
@@ -28,7 +28,6 @@ module Brightbox
       c.switch %i[e base64], :negatable => true
 
       c.desc "Enable encryption at rest for disk"
-      c.default_value false
       c.switch ["disk-encrypted"], :negatable => false
 
       c.desc "Server groups to place server in - comma delimited list"

--- a/lib/brightbox-cli/commands/servers/update.rb
+++ b/lib/brightbox-cli/commands/servers/update.rb
@@ -17,7 +17,7 @@ module Brightbox
       c.switch %i[e base64], :negatable => true
 
       c.desc "Use compatibility mode"
-      c.switch [:"compatibility-mode"], :negatable => true
+      c.switch [:"compatibility-mode"], ignore_default: true
 
       c.desc "Server groups to place server in - comma delimited list"
       c.flag [:g, "server-groups"]

--- a/lib/brightbox-cli/commands/volumes/update.rb
+++ b/lib/brightbox-cli/commands/volumes/update.rb
@@ -8,8 +8,7 @@ module Brightbox
       c.flag %i[d description]
 
       c.desc I18n.t("volumes.options.delete_with_server")
-      c.default_value :ignore # So we can discard unless deliberately passed
-      c.switch ["delete-with-server"], negatable: true
+      c.switch [:"delete-with-server"], ignore_default: true
 
       c.desc I18n.t("options.name.desc")
       c.flag %i[n name]
@@ -28,8 +27,8 @@ module Brightbox
 
         # Switches will always appear in the options so we need a non-boolean
         # setting to determine if the user did not add it to their command
-        unless options["delete-with-server"] == :ignore
-          params[:delete_with_server] = options["delete-with-server"]
+        unless options[:"delete-with-server"].nil?
+          params[:delete_with_server] = options[:"delete-with-server"]
         end
 
         params[:description] = options[:description] if options[:description]

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -23,6 +23,7 @@ end
 require "multi_json"
 require "date"
 require "gli"
+require "gli_patches"
 require "i18n"
 require "fog/brightbox"
 

--- a/lib/gli_patches.rb
+++ b/lib/gli_patches.rb
@@ -1,0 +1,50 @@
+require "gli/dsl"
+require "gli/command_line_option"
+require "gli/option_parser_factory"
+
+module GLI
+  module DSL
+    def extract_options(names)
+      options = {}
+      options = names.pop if names.last.kind_of? Hash
+      options = {
+        :desc => @next_desc,
+        :long_desc => @next_long_desc,
+        :default_value => @next_default_value,
+        :ignore_default => @ignore_default,
+        :arg_name => @next_arg_name
+      }.merge(options)
+    end
+  end
+
+  class CommandLineOption
+    def initialize(names, options = {})
+      # Disable returning a default for this option (needed for boolean updates)
+      # which should NOT be sent unless added by the user
+      @ignore_default = !!options[:ignore_default]
+
+      super(names, options[:desc], options[:long_desc])
+      @default_value = options[:default_value]
+    end
+
+    def ignore_default?
+      @ignore_default
+    end
+  end
+
+  class OptionParserFactory
+    private
+
+    def set_defaults(options_by_name,options_hash)
+      options_by_name.values.each do |option|
+        option.names_and_aliases.each do |option_name|
+          [option_name,option_name.to_sym].each do |name|
+            next if option.ignore_default?
+
+            options_hash[name] = option.default_value if options_hash[name].nil?
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/cloudips/update_spec.rb
+++ b/spec/commands/cloudips/update_spec.rb
@@ -1,82 +1,162 @@
 require "spec_helper"
 
-describe "brightbox cloudips" do
-  describe "update" do
-    let(:output) { FauxIO.new { Brightbox.run(argv) } }
-    let(:stdout) { output.stdout }
-    let(:stderr) { output.stderr }
+describe "brightbox cloudips update" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "" do
+    let(:argv) { %w[cloudips update] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+    end
+  end
+
+  context "when name is updated" do
+    let(:argv) { ["cloudips", "update", "--name=#{new_name}", "cip-12345"] }
+
+    let(:json_response) do
+      <<-EOS
+      {
+        "id":"cip-12345",
+        "name":"#{new_name}"
+      }
+      EOS
+    end
+
+    context "--name 'New name'" do
+      let(:new_name) { "New name" }
+      let(:expected_args) { ["cip-12345", { :name => new_name }] }
+
+      before do
+        stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          .with(:headers => { "Content-Type" => "application/json" },
+                :body => {
+                  name: "New name"
+                })
+          .and_return(:status => 200, :body => json_response)
+
+        stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          .with(:headers => { "Content-Type" => "application/json" })
+          .and_return(:status => 200, :body => json_response)
+      end
+
+      it "puts new name in update" do
+        expect(Brightbox::CloudIP.conn).to receive(:update_cloud_ip).with(*expected_args).and_call_original
+        expect(stderr).to eq("")
+        expect(stdout).to include("cip-12345")
+        expect(stdout).to include("New name")
+      end
+    end
+
+    context "--name ''" do
+      let(:new_name) { "" }
+      let(:expected_args) { ["cip-12345", { :name => "" }] }
+
+      before do
+        stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          .with(:headers => { "Content-Type" => "application/json" },
+                :body => hash_including("name" => ""))
+          .and_return(:status => 200, :body => json_response)
+
+        stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
+          .with(:headers => { "Content-Type" => "application/json" })
+          .and_return(:status => 200, :body => json_response)
+      end
+
+      it "puts new name in update" do
+        expect(Brightbox::CloudIP.conn).to receive(:update_cloud_ip).with(*expected_args).and_call_original
+        expect(stderr).to eq("")
+        expect(stdout).to include("cip-12345")
+      end
+    end
+  end
+
+  context "--reverse-dns" do
+    let(:argv) { ["cloudips", "update", "--reverse-dns", "domain.example", "cip-dfsa3"] }
+
+    let(:json_response) do
+      <<-EOS
+      {
+        "id":"cip-dfsa3",
+        "reverse_dns":"domain.example"
+      }
+      EOS
+    end
 
     before do
-      config_from_contents(USER_APP_CONFIG_CONTENTS)
+      stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-dfsa3?account_id=acc-12345")
+        .with(:headers => { "Content-Type" => "application/json" },
+              :body => {
+                reverse_dns: "domain.example"
+              })
+        .and_return(:status => 200, :body => json_response)
 
-      stub_request(:post, "http://api.brightbox.localhost/token")
-        .to_return(status: 200, body: JSON.dump(access_token: "ACCESS-TOKEN", refresh_token: "REFRESH-TOKEN"))
+      stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-dfsa3?account_id=acc-12345")
+        .with(:headers => { "Content-Type" => "application/json" })
+        .and_return(:status => 200, :body => json_response)
     end
 
-    context "" do
-      let(:argv) { %w[cloudips update] }
+    it "puts new name in update" do
+      expect(stderr).to eq("")
+      expect(stdout).to include("cip-dfsa3")
+      expect(stdout).to include("domain.example")
+    end
+  end
 
-      it "does not error" do
-        expect { output }.to_not raise_error
-      end
+  context "--delete-reverse-dns" do
+    let(:argv) { ["cloudips", "update", "--delete-reverse-dns", "cip-dfsa3"] }
+
+    let(:json_response) do
+      <<-EOS
+      {
+        "id":"cip-dfsa3",
+        "reverse_dns":""
+      }
+      EOS
     end
 
-    context "when name is updated" do
-      let(:argv) { ["cloudips", "update", "--name=#{new_name}", "cip-12345"] }
+    before do
+      stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-dfsa3?account_id=acc-12345")
+        .with(:headers => { "Content-Type" => "application/json" },
+              :body => {
+                reverse_dns: ""
+              })
+        .and_return(:status => 200, :body => json_response)
 
-      let(:json_response) do
-        <<-EOS
-        {
-          "id":"cip-12345",
-          "name":"#{new_name}"
-        }
-        EOS
-      end
+      stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-dfsa3?account_id=acc-12345")
+        .with(:headers => { "Content-Type" => "application/json" })
+        .and_return(:status => 200, :body => json_response)
+    end
 
-      context "--name 'New name'" do
-        let(:new_name) { "New name" }
-        let(:expected_args) { ["cip-12345", { :name => new_name }] }
+    it "puts new name in update" do
+      expect(stderr).to eq("")
+      expect(stdout).to include("cip-dfsa3")
+    end
+  end
 
-        before do
-          stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
-            .with(:headers => { "Content-Type" => "application/json" },
-                  :body => hash_including("name" => "New name"))
-            .and_return(:status => 200, :body => json_response)
+  context "--reverse-dns and --delete-reverse-dns options" do
+    let(:argv) { ["cloudips", "update", "--reverse-dns", "domain.example", "--delete-reverse-dns", "cip-dfsa3"] }
 
-          stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
-            .with(:headers => { "Content-Type" => "application/json" })
-            .and_return(:status => 200, :body => json_response)
-        end
-
-        it "puts new name in update" do
-          expect(Brightbox::CloudIP.conn).to receive(:update_cloud_ip).with(*expected_args).and_call_original
-          expect(stderr).to eq("")
-          expect(stdout).to include("cip-12345")
-          expect(stdout).to include("New name")
-        end
-      end
-
-      context "--name ''" do
-        let(:new_name) { "" }
-        let(:expected_args) { ["cip-12345", { :name => "" }] }
-
-        before do
-          stub_request(:put, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
-            .with(:headers => { "Content-Type" => "application/json" },
-                  :body => hash_including("name" => ""))
-            .and_return(:status => 200, :body => json_response)
-
-          stub_request(:get, "http://api.brightbox.localhost/1.0/cloud_ips/cip-12345?account_id=acc-12345")
-            .with(:headers => { "Content-Type" => "application/json" })
-            .and_return(:status => 200, :body => json_response)
-        end
-
-        it "puts new name in update" do
-          expect(Brightbox::CloudIP.conn).to receive(:update_cloud_ip).with(*expected_args).and_call_original
-          expect(stderr).to eq("")
-          expect(stdout).to include("cip-12345")
-        end
-      end
+    it "puts new name in update" do
+      expect(stderr).to eq("ERROR: You must either specify a reverse DNS record or --delete-reverse-dns\n")
+      expect(stdout).to eq("")
     end
   end
 end

--- a/spec/commands/lbs/update_spec.rb
+++ b/spec/commands/lbs/update_spec.rb
@@ -36,13 +36,67 @@ describe "brightbox lbs" do
           .to_return(:status => 200, :body => '{"id":"lba-12345"}')
 
         stub_request(:put, "http://api.brightbox.localhost/1.0/load_balancers/lba-12345?account_id=acc-12345")
-          .with(:body => hash_including("ssl_minimum_version" => "TLSv1.0"))
+          .with(:body => { ssl_minimum_version: "TLSv1.0" })
           .to_return(:status => 202, :body => json_response)
       end
 
       it "includes ssl_minimum_version in response" do
         expect(stderr).to eq("Updating load balancer lba-12345\n")
         expect(stdout).to include("lba-12345")
+      end
+    end
+
+    context "--sslv3" do
+      let(:argv) { ["lbs", "update", "--sslv3", "lba-grt24"] }
+
+      let(:json_response) do
+        <<-EOS
+        {
+          "id":"lba-grt24",
+          "ssl_minimum_version":"TLSv1.0"
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/load_balancers/lba-grt24?account_id=acc-12345")
+          .to_return(:status => 200, :body => '{"id":"lba-grt24"}')
+
+        stub_request(:put, "http://api.brightbox.localhost/1.0/load_balancers/lba-grt24?account_id=acc-12345")
+          .with(:body => { sslv3: true })
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "includes ssl_minimum_version in response" do
+        expect(stderr).to eq("Updating load balancer lba-grt24\n")
+        expect(stdout).to include("lba-grt24")
+      end
+    end
+
+    context "--no-sslv3" do
+      let(:argv) { ["lbs", "update", "--no-sslv3", "lba-kl432"] }
+
+      let(:json_response) do
+        <<-EOS
+        {
+          "id":"lba-kl432",
+          "ssl_minimum_version":"TLSv1.0"
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/load_balancers/lba-kl432?account_id=acc-12345")
+          .to_return(:status => 200, :body => '{"id":"lba-kl432"}')
+
+        stub_request(:put, "http://api.brightbox.localhost/1.0/load_balancers/lba-kl432?account_id=acc-12345")
+          .with(:body => { sslv3: false })
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "includes ssl_minimum_version in response" do
+        expect(stderr).to eq("Updating load balancer lba-kl432\n")
+        expect(stdout).to include("lba-kl432")
       end
     end
   end

--- a/spec/commands/servers/create_spec.rb
+++ b/spec/commands/servers/create_spec.rb
@@ -38,7 +38,10 @@ describe "brightbox servers" do
 
       it "does not error" do
         stub_request(:post, "http://api.brightbox.localhost/1.0/servers?account_id=acc-12345")
-          .with(:body => hash_including(image: "img-12345"))
+          .with(:body => {
+            image: "img-12345",
+            server_type: "typ-12345"
+          })
           .and_return(:status => 202, :body => sample_response)
 
         expect(stderr).not_to match("ERROR")
@@ -94,8 +97,12 @@ describe "brightbox servers" do
 
       it "requests new server with encryption at rest enabled" do
         stub_request(:post, "http://api.brightbox.localhost/1.0/servers?account_id=acc-12345")
-          .with(:headers => { "Content-Type" => "application/json" },
-                :body => hash_including(:disk_encrypted => true))
+          .with(headers: { "Content-Type" => "application/json" },
+                body: {
+                  disk_encrypted: true,
+                  image: "img-12345",
+                  server_type: "typ-12345"
+                })
           .and_return(:status => 202, :body => sample_response)
 
         expect(stderr).to match("Creating a nano")

--- a/spec/commands/servers/update_spec.rb
+++ b/spec/commands/servers/update_spec.rb
@@ -1,17 +1,272 @@
 require "spec_helper"
 
-describe "brightbox servers" do
-  describe "update" do
-    let(:output) { FauxIO.new { Brightbox.run(argv) } }
-    let(:stdout) { output.stdout }
-    let(:stderr) { output.stderr }
+describe "brightbox servers update" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
 
-    context "" do
-      let(:argv) { %w[servers update] }
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
 
-      it "does not error" do
-        expect { output }.to_not raise_error
-      end
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[servers update] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify a valid server id as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "without options" do
+    let(:argv) { %w[servers update srv-klfkd] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/servers/srv-klfkd?account_id=acc-12345")
+        .to_return(:status => 200, :body => {
+          id: "srv-klfkd",
+          server_type: {
+           id: "typ-12345"
+          },
+          cloud_ips: [],
+          interfaces: []
+        }.to_json)
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345")
+        .to_return(:status => 200, :body => [{id: "img-12345" }].to_json)
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/servers/srv-klfkd?account_id=acc-12345")
+        .with(:body => {
+          compatibility_mode: false
+        })
+        .to_return(:status => 200, :body => {
+           id: "srv-klfkd",
+           server_type: {
+            id: "typ-12345"
+           },
+           cloud_ips: [],
+           interfaces: []
+        }.to_json)
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating server srv-klfkd\n")
+
+      expect(stdout).to match("srv-klfkd")
+    end
+  end
+
+  context "with --compatibility-mode" do
+    let(:argv) { %w[servers update --compatibility-mode srv-ds321] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .to_return(:status => 200, :body => {
+          id: "srv-ds321",
+          server_type: {
+           id: "typ-12345"
+          },
+          cloud_ips: [],
+          interfaces: []
+        }.to_json)
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345")
+        .to_return(:status => 200, :body => [{id: "img-12345" }].to_json)
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .with(:body => {})
+        .to_return(:status => 200, :body => {
+           id: "srv-ds321",
+           server_type: {
+            id: "typ-12345"
+           },
+           cloud_ips: [],
+           interfaces: []
+        }.to_json)
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating server srv-ds321\n")
+
+      expect(stdout).to match("srv-ds321")
+    end
+  end
+
+  context "with --no-compatibility-mode" do
+    let(:argv) { %w[servers update --no-compatibility-mode srv-ds321] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .to_return(:status => 200, :body => {
+          id: "srv-ds321",
+          server_type: {
+           id: "typ-12345"
+          },
+          cloud_ips: [],
+          interfaces: []
+        }.to_json)
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345")
+        .to_return(:status => 200, :body => [{id: "img-12345" }].to_json)
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .with(:body => {
+          compatibility_mode: false
+        })
+        .to_return(:status => 200, :body => {
+           id: "srv-ds321",
+           server_type: {
+            id: "typ-12345"
+           },
+           cloud_ips: [],
+           interfaces: []
+        }.to_json)
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating server srv-ds321\n")
+
+      expect(stdout).to match("srv-ds321")
+    end
+  end
+
+  context "with --base64" do
+    let(:argv) { %w[servers update --base64 srv-ds321] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .to_return(:status => 200, :body => {
+          id: "srv-ds321",
+          server_type: {
+           id: "typ-12345"
+          },
+          cloud_ips: [],
+          interfaces: []
+        }.to_json)
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345")
+        .to_return(:status => 200, :body => [{id: "img-12345" }].to_json)
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .with(:body => {
+          compatibility_mode: false
+        })
+        .to_return(:status => 200, :body => {
+           id: "srv-ds321",
+           server_type: {
+            id: "typ-12345"
+           },
+           cloud_ips: [],
+           interfaces: []
+        }.to_json)
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating server srv-ds321\n")
+
+      expect(stdout).to match("srv-ds321")
+    end
+  end
+
+  context "with --base64 --user-data" do
+    let(:argv) { %w[servers update --base64 --user-data hello srv-ds321] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .to_return(:status => 200, :body => {
+          id: "srv-ds321",
+          server_type: {
+           id: "typ-12345"
+          },
+          cloud_ips: [],
+          interfaces: []
+        }.to_json)
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345")
+        .to_return(:status => 200, :body => [{id: "img-12345" }].to_json)
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .with(:body => {
+          user_data: "aGVsbG8=\n"
+        })
+        .to_return(:status => 200, :body => {
+           id: "srv-ds321",
+           server_type: {
+            id: "typ-12345"
+           },
+           cloud_ips: [],
+           interfaces: []
+        }.to_json)
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating server srv-ds321 with 0.01k of user data\n")
+
+      expect(stdout).to match("srv-ds321")
+    end
+  end
+
+  context "with --no-base64 --user-data" do
+    let(:argv) { %w[servers update --no-base64 --user-data hello srv-ds321] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .to_return(:status => 200, :body => {
+          id: "srv-ds321",
+          server_type: {
+           id: "typ-12345"
+          },
+          cloud_ips: [],
+          interfaces: []
+        }.to_json)
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/images?account_id=acc-12345")
+        .to_return(:status => 200, :body => [{id: "img-12345" }].to_json)
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/servers/srv-ds321?account_id=acc-12345")
+        .with(:body => {
+          user_data: "hello"
+        })
+        .to_return(:status => 200, :body => {
+           id: "srv-ds321",
+           server_type: {
+            id: "typ-12345"
+           },
+           cloud_ips: [],
+           interfaces: []
+        }.to_json)
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating server srv-ds321 with 0.00k of user data\n")
+
+      expect(stdout).to match("srv-ds321")
     end
   end
 end

--- a/spec/commands/sql/instances/update_spec.rb
+++ b/spec/commands/sql/instances/update_spec.rb
@@ -26,7 +26,7 @@ describe "brightbox sql instances" do
                        "maintenance_hour":6}')
 
         stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
-          .with(:body => "{\"maintenance_weekday\":\"1\"}")
+          .with(body: { maintenance_weekday: "1" }.to_json)
       end
 
       it "sets custom maintenance window settings" do
@@ -46,6 +46,7 @@ describe "brightbox sql instances" do
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
 
         stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
+          .with(body: { snapshots_schedule: "0 12 * * 4" }.to_json)
           .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
       end
 
@@ -59,25 +60,26 @@ describe "brightbox sql instances" do
     end
 
     context "--remove-snapshots-schedule" do
-      let(:dbs) { Brightbox::DatabaseServer.find("dbs-12345") }
-      let(:argv) { %w[sql instances update --remove-snapshots-schedule dbs-12345] }
+      let(:dbs) { Brightbox::DatabaseServer.find("dbs-432sf") }
+      let(:argv) { %w[sql instances update --remove-snapshots-schedule dbs-432sf] }
       let(:expected_args) { { :snapshots_schedule => nil } }
 
       before do
-        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
-          .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
-          .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
+        stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-432sf?account_id=acc-12345")
+          .to_return(:status => 200, :body => '{"id":"dbs-432sf","snapshots_schedule":"34 12 * * 4","snapshots_schedule_next_at":"2016-07-07T12:34:56Z"}')
+          .to_return(:status => 200, :body => '{"id":"dbs-432sf","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
 
-        stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-12345?account_id=acc-12345")
-          .to_return(:status => 200, :body => '{"id":"dbs-12345","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
+        stub_request(:put, "http://api.brightbox.localhost/1.0/database_servers/dbs-432sf?account_id=acc-12345")
+          .with(body: { snapshots_schedule: nil }.to_json)
+          .to_return(:status => 200, :body => '{"id":"dbs-432sf","snapshots_schedule":null,"snapshots_schedule_next_at":null}')
       end
 
       it "clears snapshots schedule" do
         expect(Brightbox::DatabaseServer).to receive(:find).and_return(dbs)
         expect(dbs).to receive(:update).with(expected_args).and_call_original
 
-        expect(stderr).to eq("Updating dbs-12345\n")
-        expect(stdout).to include("dbs-12345")
+        expect(stderr).to eq("Updating dbs-432sf\n")
+        expect(stdout).to include("dbs-432sf")
       end
     end
   end

--- a/spec/commands/volumes/update_spec.rb
+++ b/spec/commands/volumes/update_spec.rb
@@ -46,7 +46,6 @@ describe "brightbox volumes update" do
           id: "vol-908us",
           name: "Old",
           description: nil,
-          delete_with_server: true,
           serial: "vol-908us"
         )
       )


### PR DESCRIPTION
The GLI frameworks assumes that if a switch is defined, it should always be present with a `true` or `false`. This prevents using switches to represent boolean API settings since defining one injects it into the parsed arguments.

This can not be detected within CLI actions, we can not tell if the user passed `--feature`, `--no-feature`, or did not include the flag at all. This may result in a `update --name New` call also setting the feature to a default of false.

The default can be abused with a non-boolean value and used to remove it from the parameters passed to the API but being `truthy` results in the CLI help being incorrect. It lists a default when there isn't one.

This monkey patches GLI to support a `ignore_default` option which can be set to `true` and it is skipped when defaults are being generated.

This can then be correctly checked for, as the key is missing within the action and we can correctly NOT send the parameter to an API call.