### PR TITLE
Add `configmaps` management subcommands

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (4.3.2)
       dry-inflector (= 0.2.0)
-      fog-brightbox (>= 1.9.1)
+      fog-brightbox (>= 1.10.0)
       fog-core (< 2.0)
       gli (~> 2.21)
       highline (~> 2.0)
@@ -25,8 +25,8 @@ GEM
       rexml
     diff-lcs (1.5.0)
     dry-inflector (0.2.0)
-    excon (0.97.1)
-    fog-brightbox (1.9.1)
+    excon (0.97.2)
+    fog-brightbox (1.10.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.9.1"
+  s.add_dependency "fog-brightbox", ">= 1.10.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21"
   s.add_dependency "highline", "~> 2.0"

--- a/lib/brightbox-cli/commands/configmaps.rb
+++ b/lib/brightbox-cli/commands/configmaps.rb
@@ -1,0 +1,183 @@
+module Brightbox
+  desc I18n.t("configmaps.desc")
+  command [:configmaps] do |cmd|
+    cmd.default_command :list
+
+    cmd.desc I18n.t("configmaps.create.desc")
+    cmd.arg_name I18n.t("configmaps.args.one")
+    cmd.command [:create] do |c|
+      c.desc I18n.t("options.name.desc")
+      c.flag %i[n name]
+
+      c.desc I18n.t("configmaps.options.data_string")
+      c.flag %i[d data]
+
+      c.desc I18n.t("configmaps.options.data_file")
+      c.flag [:"data-file"]
+
+      c.action do |global_options, options, _args|
+        map_data = parse_configmap_data_options(options)
+
+        raise I18n.t("configmaps.create.data_required") if map_data.nil?
+
+        # Attempt to parse data as JSON but do not update
+        begin
+          JSON.parse(map_data)
+        rescue StandardError
+          raise I18n.t("configmaps.options.bad_data")
+        end
+
+        params = {
+          data: map_data
+        }
+        params[:name] = options[:name] if options[:name]
+
+        info I18n.t("configmaps.create.acting")
+        config_map = ConfigMap.create(params)
+
+        render_table([config_map], global_options)
+      end
+    end
+
+    cmd.desc I18n.t("configmaps.destroy.desc")
+    cmd.arg_name I18n.t("configmaps.args.many")
+    cmd.command [:destroy] do |c|
+      c.action do |_global_options, _options, args|
+        raise I18n.t("configmaps.args.specify_many_ids") if args.empty?
+
+        config_maps = ConfigMap.find_or_call(args) do |id|
+          raise I18n.t("configmaps.args.unknown_id", config_map: id)
+        end
+
+        config_maps.each do |config_map|
+          info I18n.t("configmaps.destroy.acting", config_map: config_map)
+
+          begin
+            config_map.destroy
+          rescue Brightbox::Api::Conflict
+            error I18n.t("configmaps.destroy.failed", config_map: id)
+          end
+        end
+      end
+    end
+
+    cmd.desc I18n.t("configmaps.list.desc")
+    cmd.arg_name I18n.t("configmaps.args.optional")
+    cmd.command [:list] do |c|
+      c.action do |global_options, _options, args|
+        config_maps = ConfigMap.find_all_or_warn(args)
+
+        render_table(config_maps, global_options)
+      end
+    end
+
+    cmd.desc I18n.t("configmaps.show.desc")
+    cmd.arg_name I18n.t("configmaps.args.optional")
+    cmd.command [:show] do |c|
+      c.desc I18n.t("configmaps.options.data_output")
+      c.switch [:data], negatable: false, default: false
+
+      c.desc I18n.t("configmaps.options.data_format")
+      c.flag [:format]
+
+      c.action do |global_options, options, args|
+        if options[:data]
+          unless args.length == 1
+            raise I18n.t("configmaps.options.data_args")
+          end
+
+          cfg_id = args[0]
+
+          if cfg_id.nil? || !cfg_id.start_with?("cfg-")
+            raise I18n.t("configmaps.args.specify_one_id_first")
+          end
+
+          config_map = ConfigMap.find(cfg_id)
+          data(config_map.format_data(options[:format] || "json"))
+        else
+          if options[:format] && !options[:data]
+            raise I18n.t("configmaps.options.format_no_data")
+          end
+
+          config_maps = ConfigMap.find_all_or_warn(args)
+
+          table_opts = global_options.merge(
+            vertical: true
+          )
+          render_table(config_maps, table_opts)
+        end
+      end
+    end
+
+    cmd.desc I18n.t("configmaps.update.desc")
+    cmd.arg_name I18n.t("configmaps.args.one")
+    cmd.command [:update] do |c|
+      c.desc I18n.t("options.name.desc")
+      c.flag %i[n name]
+
+      c.desc I18n.t("configmaps.options.data_string")
+      c.flag %i[d data]
+
+      c.desc I18n.t("configmaps.options.data_file")
+      c.flag [:"data-file"]
+
+      c.action do |global_options, options, args|
+        cfg_id = args[0]
+
+        if cfg_id.nil? || !cfg_id.start_with?("cfg-")
+          raise I18n.t("configmaps.args.specify_one_id_first")
+        end
+
+        params = {}
+        params[:name] = options[:name] if options[:name]
+
+        map_data = parse_configmap_data_options(options)
+
+        if map_data
+          begin
+            map_data = JSON.parse(map_data)
+          rescue StandardError
+            raise I18n.t("configmaps.options.bad_data")
+          end
+
+          params[:data] = map_data
+        end
+
+        config_map = ConfigMap.find(cfg_id)
+
+        unless params.empty?
+          info I18n.t("configmaps.update.acting", config_map: config_map)
+          config_map.update(params)
+        end
+
+        render_table([config_map], global_options)
+      end
+    end
+  end
+
+  def parse_configmap_data_options(options)
+    if options[:data] && options[:"data-file"]
+      raise I18n.t("configmaps.options.multiple_data")
+    end
+
+    map_data = options[:data]
+    data_filename = options[:"data-file"]
+
+    if data_filename
+      file_handler = lambda do |file|
+        map_data = file.read
+      end
+
+      if data_filename == "-"
+        file_handler[$stdin]
+      else
+        File.open(data_filename, "r", &file_handler)
+      end
+
+      raise map_data.inspect if map_data.nil? || map_data == ""
+    end
+
+    map_data
+  end
+  module_function :parse_configmap_data_options
+end

--- a/lib/brightbox-cli/config_map.rb
+++ b/lib/brightbox-cli/config_map.rb
@@ -1,0 +1,53 @@
+module Brightbox
+  class ConfigMap < Api
+    def self.require_account?; true; end
+
+    def self.all
+      conn.config_maps
+    end
+
+    def self.create(options)
+      new(conn.config_maps.create(options))
+    end
+
+    def self.get(id)
+      conn.config_maps.get(id)
+    end
+
+    def self.default_field_order
+      %i[id name]
+    end
+
+    def self.detailed_fields
+      %i[
+        id
+        name
+      ]
+    end
+
+    def format_data(format)
+      case format.to_sym
+      when :text
+        attributes[:data].map do |key, value|
+          "#{key.to_s.rjust(16)}: #{value}"
+        end.join("\n")
+      else
+        JSON.dump(data)
+      end
+    end
+
+    def to_row
+      {
+        id: attributes[:id],
+        name: attributes[:name],
+        data: attributes[:data]
+      }
+    end
+
+    def update(options)
+      self.class.conn.update_config_map(id, options)
+      reload
+      self
+    end
+  end
+end

--- a/lib/brightbox_cli.rb
+++ b/lib/brightbox_cli.rb
@@ -53,6 +53,7 @@ module Brightbox
   autoload :FirewallRule, File.expand_path("brightbox-cli/firewall_rule", __dir__)
   autoload :FirewallRules, File.expand_path("brightbox-cli/firewall_rules", __dir__)
   autoload :Collaboration, File.expand_path("brightbox-cli/collaboration", __dir__)
+  autoload :ConfigMap, File.expand_path("brightbox-cli/config_map", __dir__)
   autoload :UserCollaboration, File.expand_path("brightbox-cli/user_collaboration", __dir__)
   autoload :DatabaseType, File.expand_path("brightbox-cli/database_type", __dir__)
   autoload :DatabaseServer, File.expand_path("brightbox-cli/database_server", __dir__)

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -51,6 +51,39 @@ en:
       desc: Remove an API client from config
     user_add:
       desc: Add new user credentials to config
+  configmaps:
+    desc: Manage config maps
+    args:
+      one: <configmap>
+      optional: "[<configmap>...]"
+      many: <configmap>...
+      specify_one_id_first: You must specify the config map ID as the first argument
+      specify_many_ids: You must specify config map IDs as arguments
+      unknown_id: Couldn't find %{config_map}
+    options:
+      data_args: You can only access data for a single config map at a time
+      data_file: A path to a file contain a JSON object containing key/values, or '-' for STDIO
+      data_string: String representing a valid JSON object
+      data_output: Return the config map data key/values
+      data_format: "Format to return 'data' in: 'json' (default) or 'text'"
+      format_no_data: The 'format' option can only be used with 'data'
+      bad_data: Config map data was not valid JSON
+      multiple_data: Config map data can only be passed by either 'data' or 'data-file'
+    create:
+      desc: Create a config map
+      acting: Creating config map
+      data_required: Config map data is required as 'data' option
+    destroy:
+      desc: Destroy config maps
+      acting: Destroying %{config_map}
+      failed: Failed to destroy %{config_map}
+    list:
+      desc: List config maps
+    show:
+      desc: Show config maps
+    update:
+      desc: Update a config map
+      acting: Updating %{config_map}
   firewall:
     policies:
       desc: Manage firewall policies

--- a/spec/commands/configmaps/create_spec.rb
+++ b/spec/commands/configmaps/create_spec.rb
@@ -1,0 +1,257 @@
+require "spec_helper"
+
+describe "brightbox configmaps create" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  let(:token) { SecureRandom.hex }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(status: 200, body: JSON.dump(access_token: token))
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without options" do
+    let(:argv) { %w[configmaps create] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Config map data is required as 'data' option")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with 'name' and 'data'" do
+    let(:argv) { ["configmaps", "create", "--name", "tester", "--data", payload] }
+    let(:payload) { { key: "value" }.to_json }
+
+    before do
+      stub_request(:post, "http://api.brightbox.localhost/1.0/config_maps")
+        .with(headers: { "Content-Type" => "application/json" },
+              query: hash_including(account_id: "acc-12345"),
+              body: {
+                name: "tester",
+                data: {
+                  key: "value"
+                }
+              })
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-lk342",
+            name: "tester",
+            data: {
+              key: "value"
+            }
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*name")
+
+        expect(stdout).to match("cfg-lk342")
+      end
+    end
+  end
+
+  context "with 'data'" do
+    let(:argv) { ["configmaps", "create", "--data", payload] }
+    let(:payload) { { key: "value" }.to_json }
+
+    before do
+      stub_request(:post, "http://api.brightbox.localhost/1.0/config_maps")
+        .with(headers: { "Content-Type" => "application/json" },
+              query: hash_including(account_id: "acc-12345"),
+              body: {
+                data: {
+                  key: "value"
+                }
+              }.to_json)
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-lk342",
+            data: {
+              key: "value"
+            }
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*name")
+
+        expect(stdout).to match("cfg-lk342")
+      end
+    end
+
+    context "with invalid update" do
+      let(:payload) { "Not JSON!" }
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("ERROR: Config map data was not valid JSON\n")
+
+        expect(stdout).to eq("")
+      end
+    end
+  end
+
+  context "with new map from 'data-file'" do
+    context "when filename is used" do
+      let(:argv) { ["configmaps", "create", "--data-file", data_file.path] }
+      let(:data_file) { Tempfile.open("config_map_test_data") }
+
+      around do |example|
+        data_file.write(payload)
+        data_file.close
+
+        example.run
+
+        data_file.unlink
+      end
+
+      context "with valid update" do
+        let(:payload) { { new_key: "new setting" }.to_json }
+
+        before do
+          stub_request(:post, "http://api.brightbox.localhost/1.0/config_maps")
+            .with(query: hash_including(account_id: "acc-12345"),
+                  body: {
+                    data: {
+                      new_key: "new setting"
+                    }
+                  })
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-s432l",
+                name: "",
+                data: {
+                  new_key: "new setting"
+                }
+              }.to_json
+            )
+        end
+
+        it "does not error" do
+          expect { output }.to_not raise_error
+
+          expect(stderr).to eq("Creating config map\n")
+
+          aggregate_failures do
+            expect(stdout).to match("cfg-s432l")
+          end
+        end
+
+        context "with invalid update" do
+          let(:payload) { "Not JSON!" }
+
+          it "does not error" do
+            expect { output }.to_not raise_error
+
+            expect(stderr).to eq("ERROR: Config map data was not valid JSON\n")
+
+            expect(stdout).to eq("")
+          end
+        end
+      end
+    end
+  end
+
+  context "when '-' is used for STDIN" do
+    let(:argv) { ["configmaps", "create", "--data-file", "-", "cfg-stdin"] }
+
+    before do
+      stdin_data = StringIO.new
+      stdin_data.puts(payload)
+      stdin_data.rewind
+
+      $stdin = stdin_data
+    end
+
+    after do
+      $stdin = STDIN
+    end
+
+    context "with valid update" do
+      let(:payload) { { use_stdin: true }.to_json }
+
+      before do
+        stub_request(:post, "http://api.brightbox.localhost/1.0/config_maps")
+          .with(query: hash_including(account_id: "acc-12345"),
+                body: {
+                  data: {
+                    use_stdin: true
+                  }
+                })
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-mj53s",
+              name: "",
+              data: {
+                use_stdin: true
+              }
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("Creating config map\n")
+
+        aggregate_failures do
+          expect(stdout).to match("cfg-mj53s")
+        end
+      end
+
+      context "with invalid update" do
+        let(:payload) { "Not JSON!" }
+
+        it "does not error" do
+          expect { output }.to_not raise_error
+
+          expect(stderr).to eq("ERROR: Config map data was not valid JSON\n")
+
+          expect(stdout).to eq("")
+        end
+      end
+    end
+  end
+
+  context "with mutually exclusive data options" do
+    let(:argv) { ["configmaps", "create", "--data", payload, "--data-file", "-"] }
+    let(:payload) { { new_key: "new value" }.to_json }
+
+    context "with invalid update" do
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("ERROR: Config map data can only be passed by either 'data' or 'data-file'\n")
+
+        expect(stdout).to eq("")
+      end
+    end
+  end
+end

--- a/spec/commands/configmaps/destroy_spec.rb
+++ b/spec/commands/configmaps/destroy_spec.rb
@@ -1,0 +1,156 @@
+require "spec_helper"
+
+describe "brightbox configmaps destroy" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[configmaps destroy] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify config map IDs as arguments\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with one argument" do
+    let(:argv) { %w[configmaps destroy cfg-xdwe2] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-xdwe2")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-xdwe2"
+          }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-xdwe2"
+          }.to_json
+        )
+
+      stub_request(:delete, "http://api.brightbox.localhost/1.0/config_maps/cfg-xdwe2")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: {
+            id: "cfg-xdwe2"
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Destroying cfg-xdwe2\n")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with multiple arguments" do
+    let(:argv) { %w[configmaps destroy cfg-12ds4 cfg-vf567] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-12ds4")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-12ds4"
+          }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-12ds4"
+          }.to_json
+        )
+
+      stub_request(:delete, "http://api.brightbox.localhost/1.0/config_maps/cfg-12ds4")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-12ds4"
+          }.to_json
+        )
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-vf567")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-vf567"
+          }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-vf567"
+          }.to_json
+        )
+
+      stub_request(:delete, "http://api.brightbox.localhost/1.0/config_maps/cfg-vf567")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-vf567"
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Destroying cfg-12ds4\n")
+      expect(stderr).to match("Destroying cfg-vf567\n")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with unknown argument" do
+    let(:argv) { %w[configmaps destroy cfg-lk234] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-lk234")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 404,
+          body: ""
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("Couldn't find cfg-lk234\n")
+
+      expect(stdout).to eq("")
+    end
+  end
+end

--- a/spec/commands/configmaps/list_spec.rb
+++ b/spec/commands/configmaps/list_spec.rb
@@ -1,0 +1,96 @@
+require "spec_helper"
+
+describe "brightbox configmaps list" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[configmaps list] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: config_maps_response
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*name")
+
+        expect(stdout).to match("cfg-12345")
+        expect(stdout).to match("Test 12345")
+
+        expect(stdout).to match("cfg-abcde")
+        expect(stdout).to match("Test ABCDE")
+      end
+    end
+  end
+
+  context "with identifier" do
+    let(:argv) { %w[configmaps list cfg-312re] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-312re")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-312re",
+            name: "My config",
+            data: {
+              key: "value"
+            }
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id.*name")
+
+        expect(stdout).to match("cfg-312re")
+        expect(stdout).to match("My config")
+      end
+    end
+  end
+
+  def config_maps_response
+    [
+      {
+        id: "cfg-12345",
+        name: "Test 12345"
+      },
+      {
+        id: "cfg-abcde",
+        name: "Test ABCDE"
+      }
+    ].to_json
+  end
+end

--- a/spec/commands/configmaps/show_spec.rb
+++ b/spec/commands/configmaps/show_spec.rb
@@ -1,0 +1,236 @@
+require "spec_helper"
+
+describe "brightbox configmaps show" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[configmaps show] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: config_maps_response
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("")
+
+      aggregate_failures do
+        expect(stdout).to match("id: cfg-12345")
+        expect(stdout).to match("id: cfg-abcde")
+      end
+    end
+  end
+
+  context "with identifier" do
+    let(:argv) { %w[configmaps show cfg-lk432] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-lk432")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-lk432",
+            name: "Staging Config Example",
+            data: {
+              key: "value"
+            }
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id: cfg-lk432")
+        expect(stdout).to match("name: Staging Config Example")
+      end
+    end
+  end
+
+  context "with '--data' output" do
+    context "with multiple IDs" do
+      let(:argv) { %w[configmaps show --data cfg-m543s cfg-klds4] }
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("ERROR: You can only access data for a single config map at a time\n")
+
+        expect(stdout).to eq("")
+      end
+    end
+
+    context "without '--format'" do
+      let(:argv) { %w[configmaps show --data cfg-xd3d4] }
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-xd3d4")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-lk432",
+              name: "Staging Config Example",
+              data: {
+                key: "value",
+                name: "key name"
+              }
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).not_to match("ERROR")
+
+        expect(stdout).to eq(%({"key":"value","name":"key name"}\n))
+      end
+    end
+
+    context "with '--format json'" do
+      let(:argv) { %w[configmaps show --data --format json cfg-xd3d4] }
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-xd3d4")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-lk432",
+              name: "Staging Config Example",
+              data: {
+                key: "value",
+                name: "key name"
+              }
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("")
+
+        expect(stdout).to eq(%({"key":"value","name":"key name"}\n))
+      end
+    end
+
+    context "without '--format text'" do
+      let(:argv) { %w[configmaps show --data --format text cfg-xd3d4] }
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-xd3d4")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-lk432",
+              name: "Staging Config Example",
+              data: {
+                key: "value",
+                name: "key name"
+              }
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).not_to match("ERROR")
+
+        aggregate_failures do
+          expect(stdout).to match("^             key: value")
+          expect(stdout).to match("^            name: key name")
+        end
+      end
+    end
+  end
+
+  context "with '--format' without 'data'" do
+    let(:argv) { %w[configmaps show --format json cfg-lk432] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to match("ERROR: The 'format' option can only be used with 'data'")
+
+      expect(stdout).to eq("")
+    end
+  end
+
+  context "with simple output" do
+    let(:argv) { %w[--simple configmaps show cfg-lk432] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-lk432")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-lk432",
+            name: "Staging Config Example",
+            data: {
+              key: "value"
+            }
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("^id\tcfg-lk432$")
+        expect(stdout).to match("^name\tStaging Config Example$")
+      end
+    end
+  end
+
+  def config_maps_response
+    [
+      {
+        id: "cfg-12345",
+        name: "Test 12345",
+        data: {}
+      },
+      {
+        id: "cfg-abcde",
+        name: "Test ABCDE",
+        data: {
+          key: "value"
+        }
+      }
+    ].to_json
+  end
+end

--- a/spec/commands/configmaps/update_spec.rb
+++ b/spec/commands/configmaps/update_spec.rb
@@ -1,0 +1,342 @@
+require "spec_helper"
+require "tempfile"
+
+describe "brightbox configmaps update" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[configmaps update] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify the config map ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with new name" do
+    let(:argv) { %w[configmaps update --name New cfg-0932s] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-0932s")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-0932s",
+            name: "Old"
+          }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-0932s",
+            name: "New",
+            data: {}
+          }.to_json
+        )
+
+      stub_request(:put, "http://api.brightbox.localhost/1.0/config_maps/cfg-0932s")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: {
+                name: "New"
+              })
+        .to_return(
+          status: 200,
+          body: {
+            id: "cfg-0932s",
+            name: "New",
+            data: {}
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Updating cfg-0932s\n")
+
+      aggregate_failures do
+        expect(stdout).to match("cfg-0932s")
+        expect(stdout).to match("New")
+      end
+    end
+  end
+
+  context "with new map from 'data'" do
+    let(:argv) { ["configmaps", "update", "--data", payload, "cfg-25hrt"] }
+
+    context "with valid update" do
+      let(:payload) { { new_key: "new value" }.to_json }
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-25hrt")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-25hrt",
+              name: "",
+              data: {
+                old_key: "old value"
+              }
+            }.to_json
+          )
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-25hrt",
+              name: "",
+              data: {
+                new_key: "new value"
+              }
+            }.to_json
+          )
+
+        stub_request(:put, "http://api.brightbox.localhost/1.0/config_maps/cfg-25hrt")
+          .with(query: hash_including(account_id: "acc-12345"),
+                body: {
+                  data: {
+                    new_key: "new value"
+                  }
+                })
+          .to_return(
+            status: 200,
+            body: {
+              id: "cfg-25hrt",
+              name: "",
+              data: {
+                new_key: "new value"
+              }
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("Updating cfg-25hrt\n")
+
+        aggregate_failures do
+          expect(stdout).to match("cfg-25hrt")
+        end
+      end
+    end
+
+    context "with invalid update" do
+      let(:payload) { "Not JSON!" }
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        expect(stderr).to eq("ERROR: Config map data was not valid JSON\n")
+
+        expect(stdout).to eq("")
+      end
+    end
+  end
+
+  context "with new map from 'data-file'" do
+    context "when filename is used" do
+      let(:argv) { ["configmaps", "update", "--data-file", data_file.path, "cfg-gr45a"] }
+      let(:data_file) { Tempfile.open("config_map_test_data") }
+
+      around do |example|
+        data_file.write(payload)
+        data_file.close
+
+        example.run
+
+        data_file.unlink
+      end
+
+      context "with valid update" do
+        let(:payload) { { new_key: "new setting" }.to_json }
+
+        before do
+          stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-gr45a")
+            .with(query: hash_including(account_id: "acc-12345"))
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-gr45a",
+                name: "",
+                data: {
+                  old_key: "old setting"
+                }
+              }.to_json
+            )
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-gr45a",
+                name: "",
+                data: {
+                  new_key: "new setting"
+                }
+              }.to_json
+            )
+
+          stub_request(:put, "http://api.brightbox.localhost/1.0/config_maps/cfg-gr45a")
+            .with(query: hash_including(account_id: "acc-12345"),
+                  body: {
+                    data: {
+                      new_key: "new setting"
+                    }
+                  })
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-gr45a",
+                name: "",
+                data: {
+                  new_key: "new setting"
+                }
+              }.to_json
+            )
+        end
+
+        it "does not error" do
+          expect { output }.to_not raise_error
+
+          expect(stderr).to eq("Updating cfg-gr45a\n")
+
+          aggregate_failures do
+            expect(stdout).to match("cfg-gr45a")
+          end
+        end
+
+        context "with invalid update" do
+          let(:payload) { "Not JSON!" }
+
+          it "does not error" do
+            expect { output }.to_not raise_error
+
+            expect(stderr).to eq("ERROR: Config map data was not valid JSON\n")
+
+            expect(stdout).to eq("")
+          end
+        end
+      end
+    end
+
+    context "when '-' is used for STDIN" do
+      let(:argv) { ["configmaps", "update", "--data-file", "-", "cfg-stdin"] }
+
+      before do
+        stdin_data = StringIO.new
+        stdin_data.puts(payload)
+        stdin_data.rewind
+
+        $stdin = stdin_data
+      end
+
+      after do
+        $stdin = STDIN
+      end
+
+      context "with valid update" do
+        let(:payload) { { use_stdin: true }.to_json }
+
+        before do
+          stub_request(:get, "http://api.brightbox.localhost/1.0/config_maps/cfg-stdin")
+            .with(query: hash_including(account_id: "acc-12345"))
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-stdin",
+                name: "",
+                data: {
+                  use_stdin: true
+                }
+              }.to_json
+            )
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-stdin",
+                name: "",
+                data: {
+                  use_stdin: true
+                }
+              }.to_json
+            )
+
+          stub_request(:put, "http://api.brightbox.localhost/1.0/config_maps/cfg-stdin")
+            .with(query: hash_including(account_id: "acc-12345"),
+                  body: {
+                    data: {
+                      use_stdin: true
+                    }
+                  })
+            .to_return(
+              status: 200,
+              body: {
+                id: "cfg-stdin",
+                name: "",
+                data: {
+                  use_stdin: true
+                }
+              }.to_json
+            )
+        end
+
+        it "does not error" do
+          expect { output }.to_not raise_error
+
+          expect(stderr).to eq("Updating cfg-stdin\n")
+
+          aggregate_failures do
+            expect(stdout).to match("cfg-stdin")
+          end
+        end
+
+        context "with invalid update" do
+          let(:payload) { "Not JSON!" }
+
+          it "does not error" do
+            expect { output }.to_not raise_error
+
+            expect(stderr).to eq("ERROR: Config map data was not valid JSON\n")
+
+            expect(stdout).to eq("")
+          end
+        end
+      end
+    end
+
+    context "with mutually exclusive data options" do
+      let(:argv) { ["configmaps", "update", "--data", payload, "--data-file", "-", "cfg-25hrt"] }
+      let(:payload) { { new_key: "new value" }.to_json }
+
+      context "with invalid update" do
+        it "does not error" do
+          expect { output }.to_not raise_error
+
+          expect(stderr).to eq("ERROR: Config map data can only be passed by either 'data' or 'data-file'\n")
+
+          expect(stdout).to eq("")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows management of Config Maps, simple key/value pairs suitable for use in configuring servers.