### PR TITLE
Add DBS `reset` and `resize` subcommands

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     brightbox-cli (4.4.0)
       dry-inflector (= 0.2.0)
-      fog-brightbox (>= 1.10.0)
+      fog-brightbox (>= 1.11.0)
       fog-core (< 2.0)
       gli (~> 2.21)
       highline (~> 2.0)
@@ -26,7 +26,7 @@ GEM
     diff-lcs (1.5.0)
     dry-inflector (0.2.0)
     excon (0.97.2)
-    fog-brightbox (1.10.0)
+    fog-brightbox (1.11.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.10.0"
+  s.add_dependency "fog-brightbox", ">= 1.11.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21"
   s.add_dependency "highline", "~> 2.0"

--- a/lib/brightbox-cli/commands/sql/instances_reset.rb
+++ b/lib/brightbox-cli/commands/sql/instances_reset.rb
@@ -1,0 +1,33 @@
+module Brightbox
+  command [:sql] do |product|
+    product.command [:instances] do |cmd|
+      cmd.desc I18n.t("sql.instances.reset_password.desc")
+      cmd.arg_name "server-id"
+      cmd.command [:reset] do |c|
+        c.action do |global_options, _options, args|
+          dbs_id = args.shift
+
+          unless dbs_id =~ /^dbs-/
+            raise I18n.t("sql.instances.args.invalid")
+          end
+
+          server = DatabaseServer.find dbs_id
+
+          info I18n.t("sql.instances.reset.acting", database_server: server)
+          begin
+            server.reset
+          rescue Brightbox::Api::Conflict
+            error I18n.t("sql.instances.reset.failed", database_server: server)
+          end
+
+          table_options = global_options.merge(
+            :vertical => true,
+            :fields => DatabaseServer.detailed_fields
+          )
+
+          render_table([server], table_options)
+        end
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/commands/sql/instances_resize.rb
+++ b/lib/brightbox-cli/commands/sql/instances_resize.rb
@@ -1,0 +1,42 @@
+module Brightbox
+  command [:sql] do |product|
+    product.command [:instances] do |cmd|
+      cmd.desc I18n.t("sql.instances.reset_password.desc")
+      cmd.arg_name "server-id"
+      cmd.command [:resize] do |c|
+        # Database type
+        c.desc I18n.t("sql.instances.options.type.desc")
+        c.flag %i[t type]
+
+        c.action do |global_options, options, args|
+          dbs_id = args.shift
+
+          unless dbs_id =~ /^dbs-/
+            raise I18n.t("sql.instances.args.invalid")
+          end
+
+          new_type = options[:type]
+          unless new_type =~ /^dbt-/
+            raise I18n.t("sql.instances.options.type.invalid")
+          end
+
+          server = DatabaseServer.find dbs_id
+
+          info I18n.t("sql.instances.resize.acting", database_server: server)
+          begin
+            server.resize(new_type: new_type)
+          rescue Brightbox::Api::Conflict
+            error I18n.t("sql.instances.resize.failed", database_server: server)
+          end
+
+          table_options = global_options.merge(
+            :vertical => true,
+            :fields => DatabaseServer.detailed_fields
+          )
+
+          render_table([server], table_options)
+        end
+      end
+    end
+  end
+end

--- a/lib/brightbox-cli/database_server.rb
+++ b/lib/brightbox-cli/database_server.rb
@@ -24,8 +24,16 @@ module Brightbox
       self
     end
 
+    def reset
+      fog_model.reset
+    end
+
     def reset_password
       fog_model.reset_password
+    end
+
+    def resize(options)
+      fog_model.resize(options[:new_type])
     end
 
     def destroy

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -207,6 +207,14 @@ en:
     desc: Manage an account's Cloud SQL instances and snapshots
     instances:
       desc: Manage Cloud SQL instances
+      args:
+        one: <sql-instance>
+        optional: "[<sql-instance>...]"
+        many: <sql-instance>...
+        specify_one_id_first: You must specify the SQL instance ID as the first argument
+        specify_many_ids: You must specify SQL instance IDs as arguments
+        invalid: You must specify a valid SQL instance ID as the first argument
+        unknown_id: Couldn't find %{database_server}
       options:
         allow_access:
           desc: Comma separated list of IPs or IDs for servers or groups to allow access
@@ -230,6 +238,7 @@ en:
           desc: Clear an existing snapshots schedule
         type:
           desc: ID of a Cloud SQL type
+          invalid: Cloud SQL type format is invalid
         zone:
           desc: Zone to locate the instance in
       create:
@@ -240,8 +249,16 @@ en:
         desc: Lock Cloud SQL instances
       list:
         desc: List Cloud SQL instances
+      reset:
+        desc: Reset a Cloud SQL instance
+        acting: Resetting %{database_server}
+        failed: Could not reset %{database_server}
       reset_password:
         desc: Reset the admin password of a Cloud SQL instance
+      resize:
+        desc: Resize a Cloud SQL instance to use a new type
+        acting: Resizing %{database_server}
+        failed: Could not resize %{database_server}
       show:
         desc: Show details of Cloud SQL instances
       snapshot:

--- a/spec/commands/sql/instances/reset_spec.rb
+++ b/spec/commands/sql/instances/reset_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+describe "brightbox sql instances reset" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[sql instances reset] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify a valid SQL instance ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with invalid ID" do
+    let(:argv) { %w[sql instances reset dbs-l3kd4] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-l3kd4")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 404,
+          body: ""
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: Couldn't find 'dbs-l3kd4'\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with valid ID" do
+    let(:argv) { %w[sql instances reset dbs-po953] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-po953")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "dbs-po953"
+          }.to_json
+        )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers/dbs-po953/reset")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 202,
+          body: {
+            id: "dbs-po953"
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Resetting dbs-po953\n")
+
+      expect(stdout).to match("dbs-po953")
+    end
+  end
+end

--- a/spec/commands/sql/instances/resize_spec.rb
+++ b/spec/commands/sql/instances/resize_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+
+describe "brightbox sql instances resize" do
+  let(:output) { FauxIO.new { Brightbox.run(argv) } }
+  let(:stdout) { output.stdout }
+  let(:stderr) { output.stderr }
+
+  before do
+    config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+
+    stub_request(:post, "http://api.brightbox.localhost/token")
+      .to_return(
+        status: 200,
+        body: JSON.dump(
+          access_token: "ACCESS-TOKEN",
+          refresh_token: "REFRESH_TOKEN"
+        )
+      )
+
+    Brightbox.config.reauthenticate
+  end
+
+  context "without arguments" do
+    let(:argv) { %w[sql instances resize] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: You must specify a valid SQL instance ID as the first argument\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with invalid ID" do
+    let(:argv) { %w[sql instances resize --type dbt-12345 dbs-xsd23] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-xsd23")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 404,
+          body: ""
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: Couldn't find 'dbs-xsd23'\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with valid ID and invalid 'type'" do
+    let(:argv) { %w[sql instances resize --type embiggen dbs-e23ss] }
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("ERROR: Cloud SQL type format is invalid\n")
+
+      expect(stdout).to match("")
+    end
+  end
+
+  context "with valid ID and 'type'" do
+    let(:argv) { %w[sql instances resize --type dbt-abcde dbs-zzasa] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/database_servers/dbs-zzasa")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: {
+            id: "dbs-zzasa",
+            database_type: "dbt-12345"
+          }.to_json
+        )
+        .to_return(
+          status: 200,
+          body: {
+            id: "dbs-zzasa",
+            database_type: "dbt-abcde"
+          }.to_json
+        )
+
+      stub_request(:post, "http://api.brightbox.localhost/1.0/database_servers/dbs-zzasa/resize")
+        .with(query: hash_including(account_id: "acc-12345"),
+              body: {
+                new_type: "dbt-abcde"
+              }
+        )
+        .to_return(
+          status: 202,
+          body: {
+            id: "dbs-zzasa",
+            database_type: "dbt-abcde"
+          }.to_json
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).to eq("Resizing dbs-zzasa\n")
+
+      expect(stdout).to match("dbs-zzasa")
+    end
+  end
+end


### PR DESCRIPTION
New API methods to support resizing of database servers and resetting of the DBMS are now covered by the following two commands:

    brightbox sql instances resize --type dbt-abcde dbs-12345
    brightbox sql instances reset dbs-12345