### PR TITLE
Remove `source` option from `images register`

### DIFF
--- a/lib/brightbox-cli/commands/images/register.rb
+++ b/lib/brightbox-cli/commands/images/register.rb
@@ -14,9 +14,6 @@ module Brightbox
       c.desc "Architecture of the image (i686 or x86_64)"
       c.flag [:a, "arch"]
 
-      c.desc "Source filename of the image you uploaded to the image library"
-      c.flag [:s, "source"]
-
       c.desc "Source server ID to create image from"
       c.flag ["server"]
 
@@ -46,9 +43,9 @@ module Brightbox
         source_options = [:s, :server, :url, :volume].map { |k| options[k] }
 
         if source_options.none?
-          raise "You must specify one of 'server', 'source', 'url', or 'volume'"
+          raise "You must specify one of 'server', 'url', or 'volume'"
         elsif !source_options.one?
-          raise "You cannot register from multiple sources. Use either 'source', 'server', 'url', or 'volume'"
+          raise "You cannot register from multiple sources. Use either 'server', 'url', or 'volume'"
         end
 
         compatibility_flag = options[:m] == "compatibility"
@@ -68,7 +65,6 @@ module Brightbox
         # These should be limited to one by the mutually exclusive check earlier
         image_options[:http_url] = options[:url] if options[:url]
         image_options[:server] = options[:server] if options[:server]
-        image_options[:source] = options[:s] if options[:s]
         image_options[:volume] = options[:volume] if options[:volume]
 
         image = Image.register(image_options)

--- a/spec/commands/images/register_spec.rb
+++ b/spec/commands/images/register_spec.rb
@@ -29,18 +29,18 @@ describe "brightbox images" do
       it "does not error" do
         expect { output }.to_not raise_error
 
-        expect(stderr).to match("ERROR: You must specify one of 'server', 'source', 'url', or 'volume'")
+        expect(stderr).to match("ERROR: You must specify one of 'server', 'url', or 'volume'")
         expect(stdout).to match("")
       end
     end
 
     context "with mutually exclusive arguments" do
-      let(:argv) { %w[images register --arch x86_64 --source test.img --url http://example.com/test.img] }
+      let(:argv) { %w[images register --arch x86_64 --server srv-12345 --url http://example.com/test.img] }
 
       it "does not error" do
         expect { output }.to_not raise_error
 
-        expect(stderr).to match("ERROR: You cannot register from multiple sources. Use either 'source', 'server', 'url', or 'volume'")
+        expect(stderr).to match("ERROR: You cannot register from multiple sources. Use either 'server', 'url', or 'volume'")
         expect(stdout).to match("")
       end
     end
@@ -58,44 +58,6 @@ describe "brightbox images" do
 
         stub_request(:post, "#{api_url}/1.0/images?account_id=acc-12345")
           .with(body: /"server":"srv-12345"/)
-          .to_return(
-            status: 201,
-            body: {
-              id: "img-12345"
-            }.to_json
-          )
-
-        stub_request(:get, "#{api_url}/1.0/images/img-12345?account_id=acc-12345")
-          .to_return(
-            status: 200,
-            body: {
-              id: "img-12345"
-            }.to_json
-          )
-      end
-
-      it "does not error" do
-        expect { output }.to_not raise_error
-
-        expect(stderr).to match("")
-        expect(stderr).not_to match("ERROR")
-        expect(stdout).to match("img-12345")
-      end
-    end
-
-    context "with 'source' argument" do
-      let(:argv) { %w[images register --arch x86_64 --source custom.img] }
-
-      before do
-        expect(Brightbox::Image).to receive(:register)
-          .with(hash_including(
-                  arch: "x86_64",
-                  source: "custom.img"
-                ))
-          .and_call_original
-
-        stub_request(:post, "#{api_url}/1.0/images?account_id=acc-12345")
-          .with(body: /"source":"custom.img"/)
           .to_return(
             status: 201,
             body: {
@@ -198,14 +160,14 @@ describe "brightbox images" do
     end
 
     context "with min-ram argument" do
-      let(:argv) { %w[images register --arch x86_64 --source custom.img --min-ram 2048] }
+      let(:argv) { %w[images register --arch x86_64 --url https://example.com/os-22.iso --min-ram 2048] }
 
       before do
         expect(Brightbox::Image).to receive(:register)
           .with(hash_including(
                   arch: "x86_64",
                   min_ram: 2048,
-                  source: "custom.img"
+                  http_url: "https://example.com/os-22.iso"
                 ))
           .and_call_original
 


### PR DESCRIPTION
The `source` option was tied to the FTP based workflow which is no longer supported. Thus the option would trigger an unresolvable error for the CLI user.

Using the `url` option against a publicly accessible image via HTTP(S), such as a temp URL in Orbit is the preferred approach to register.