### PR TITLE
Update from node 12 to 16 (node 12 will EOL soon)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
         ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "head"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):


### PR DESCRIPTION
By summer github actions will no longer support node 12 (used by checkout@v2) RM27728