### PR TITLE
Update workflow to install nominated bundler

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -31,6 +31,8 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+    - name: Install Bundler
+      run: gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1 | awk '{print $1}')
     - name: Install dependencies
       run: bundle install
     - name: Run tests

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,7 @@
 PATH
   remote: .
   specs:
-    brightbox-cli (4.8.0)
-      dry-inflector (= 0.2.0)
+    brightbox-cli (5.0.0.alpha)
       fog-brightbox (>= 1.11.0)
       fog-core (< 2.0)
       gli (~> 2.21)
@@ -24,7 +23,7 @@ GEM
     crack (0.4.5)
       rexml
     diff-lcs (1.5.0)
-    dry-inflector (0.2.0)
+    dry-inflector (1.1.0)
     excon (0.112.0)
     fog-brightbox (1.11.0)
       dry-inflector
@@ -38,18 +37,18 @@ GEM
       fog-core
       multi_json (~> 1.10)
     formatador (0.3.0)
-    gli (2.21.5)
+    gli (2.22.0)
     hashdiff (1.0.1)
     highline (2.1.0)
     hirb (0.7.3)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    logger (1.6.1)
+    logger (1.6.2)
     method_source (1.0.0)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.1001)
+    mime-types-data (3.2024.1203)
     mocha (1.14.0)
     multi_json (1.15.0)
     parallel (1.22.1)

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.metadata['rubygems_mfa_required'] = 'true'
 
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.7"
 
   s.files         = `git ls-files`.split("\n") + `find lib/brightbox-cli/vendor`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
@@ -29,11 +29,6 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", ">= 0.6", "< 1.11"
   s.add_dependency "mime-types", "~> 3.0"
   s.add_dependency "multi_json", "~> 1.11"
-
-  # Indirect dependency
-  # 0.3 drops support for Ruby < 2.7
-  # 0.2.1 drops support for Ruby < 2.6
-  s.add_dependency "dry-inflector", "= 0.2.0"
 
   s.add_development_dependency "mocha"
   s.add_development_dependency "pry-remote"

--- a/lib/brightbox-cli/version.rb
+++ b/lib/brightbox-cli/version.rb
@@ -1,3 +1,3 @@
 module Brightbox
-  VERSION = "4.8.0".freeze unless defined?(Brightbox::VERSION)
+  VERSION = "5.0.0.alpha".freeze unless defined?(Brightbox::VERSION)
 end


### PR DESCRIPTION
The version of bundler is inconsistent over versions with older Rubies attempting to use versions they do not support. This attempts to tie them together.