### PR TITLE
Fix parsing of load balancer cloud IP details

### DIFF
--- a/lib/brightbox-cli/load_balancers.rb
+++ b/lib/brightbox-cli/load_balancers.rb
@@ -31,11 +31,13 @@ module Brightbox
     end
 
     def cloud_ip_ids
-      @cloud_ip_ids ||= attributes["cloud_ips"].map { |n| n["id"] } if attributes["cloud_ips"]
+      cips = attributes["cloud_ips"] || attributes[:cloud_ips]
+      @cloud_ip_ids ||= cips.map { |n| n["id"] } if cips
     end
 
     def cloud_ips
-      @cloud_ips ||= attributes["cloud_ips"].map { |n| n["public_ip"] } if attributes["cloud_ips"]
+      cips = attributes["cloud_ips"] || attributes[:cloud_ips]
+      @cloud_ips ||= cips.map { |n| n["public_ip"] } if cips
     end
 
     def listeners


### PR DESCRIPTION
The parsed key has switched from Symbol to String and so the guard clause in part of the `lbs` command no longer reports mapped IPs.