### PR TITLE
Allow singular `firewall-policy` command version

### DIFF
--- a/lib/brightbox-cli/commands/firewall/policies_apply.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_apply.rb
@@ -1,6 +1,6 @@
 module Brightbox
   desc I18n.t("firewall.policies.desc")
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.desc I18n.t("firewall.policies.apply.desc")
     cmd.arg_name "firewall-policy-id server-group-id"
     cmd.command [:apply] do |c|

--- a/lib/brightbox-cli/commands/firewall/policies_create.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_create.rb
@@ -1,5 +1,5 @@
 module Brightbox
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.desc I18n.t("firewall.policies.create.desc")
     cmd.arg_name "[server-group-id...]"
     cmd.command [:create] do |c|

--- a/lib/brightbox-cli/commands/firewall/policies_destroy.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_destroy.rb
@@ -1,5 +1,5 @@
 module Brightbox
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.desc I18n.t("firewall.policies.destroy.desc")
     cmd.arg_name "[firewall-policy-id...]"
     cmd.command [:destroy] do |c|

--- a/lib/brightbox-cli/commands/firewall/policies_list.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_list.rb
@@ -1,5 +1,5 @@
 module Brightbox
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.default_command :list
 
     cmd.desc I18n.t("firewall.policies.list.desc")

--- a/lib/brightbox-cli/commands/firewall/policies_remove.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_remove.rb
@@ -1,5 +1,5 @@
 module Brightbox
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.desc I18n.t("firewall.policies.remove.desc")
     cmd.arg_name "firewall-policy-id server-group-id"
     cmd.command [:remove] do |c|

--- a/lib/brightbox-cli/commands/firewall/policies_show.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_show.rb
@@ -1,5 +1,5 @@
 module Brightbox
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.desc I18n.t("firewall.policies.show.desc")
     cmd.arg_name "firewall-policy-id"
     cmd.command [:show] do |c|

--- a/lib/brightbox-cli/commands/firewall/policies_update.rb
+++ b/lib/brightbox-cli/commands/firewall/policies_update.rb
@@ -1,5 +1,5 @@
 module Brightbox
-  command [:"firewall-policies"] do |cmd|
+  command ["firewall-policies", "firewall-policy"] do |cmd|
     cmd.desc I18n.t("firewall.policies.update.desc")
     cmd.arg_name "firewall-policy-id"
     cmd.command [:update] do |c|


### PR DESCRIPTION
A requested option was to support the singular version of "policies" since auto-completion does not work with "policy" like it can do with other resources just missing the "s".