### PR TITLE
Fall back to working DIR if `$HOME` unset

### DIFF
--- a/lib/brightbox-cli/config.rb
+++ b/lib/brightbox-cli/config.rb
@@ -112,7 +112,8 @@ module Brightbox
     private
 
     def default_config_dir
-      File.join(ENV.fetch("HOME", nil), ".brightbox")
+      config_dir = ENV.fetch("HOME", nil) || Dir.pwd
+      File.join(config_dir, ".brightbox")
     end
 
     def configured?

--- a/spec/unit/brightbox/bb_config/config_directory_spec.rb
+++ b/spec/unit/brightbox/bb_config/config_directory_spec.rb
@@ -2,17 +2,37 @@ require "spec_helper"
 
 describe Brightbox::BBConfig do
   describe "#config_directory" do
+    context "when HOME is not set" do
+      let(:working_dir) { Dir.mktmpdir("working") }
+
+      before do
+        allow(Dir).to receive(:pwd).and_return(working_dir)
+        allow(ENV).to receive(:fetch).with("HOME", nil).and_return(nil)
+      end
+
+      it "returns current directory" do
+        config = Brightbox::BBConfig.new
+
+        expect(config.config_directory).to start_with(working_dir)
+        expect(config.config_directory).to end_with(".brightbox")
+      end
+    end
+
     context "when default location is used" do
       it "returns a String of the users `.brightbox` directory" do
         config = Brightbox::BBConfig.new
 
         expanded_path = File.expand_path("~/.brightbox")
-        expect(config.config_directory).to eql(expanded_path)
+        expect(config.config_directory).to eq(expanded_path)
       end
     end
 
     context "when absolute custom location is set" do
       let(:custom_dir) { Dir.mktmpdir("custom") }
+
+      after do
+        FileUtils.rm_rf(custom_dir)
+      end
 
       it "returns a String of the expanded directory" do
         config_options = {
@@ -20,7 +40,7 @@ describe Brightbox::BBConfig do
         }
         config = Brightbox::BBConfig.new(config_options)
 
-        expect(config.config_directory).to eql(custom_dir)
+        expect(config.config_directory).to eq(custom_dir)
       end
     end
 
@@ -32,7 +52,7 @@ describe Brightbox::BBConfig do
         config = Brightbox::BBConfig.new(config_options)
 
         expanded_path = File.expand_path("~/.cli_config")
-        expect(config.config_directory).to eql(expanded_path)
+        expect(config.config_directory).to eq(expanded_path)
       end
     end
   end


### PR DESCRIPTION
In some container environments, `$HOME` may not be set as an ENV variable resulting in the configuration either returning `/.brightbox` or in later versions raising an error as the file path would error when joining `nil`.

For: GH-96