### PR TITLE
Update `bundler` to v2.5.23

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.33
+   2.5.23


### PR DESCRIPTION
To remove an issue with a spelling warning spamming on every run.