### PR TITLE
Update `bundler` to v2.4.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.33
+   2.4.22


### PR DESCRIPTION
To remove an issue with a spelling warning spamming on every run but limiting it to a version supported by Ruby 2.7.