### PR TITLE
Update `fog-brightbox` for v1.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     brightbox-cli (5.0.0.alpha)
-      fog-brightbox (>= 1.11.0)
+      fog-brightbox (>= 1.12.0)
       fog-core (< 2.0)
       gli (~> 2.21)
       highline (~> 2.0)
@@ -26,7 +26,7 @@ GEM
     docile (1.4.1)
     dry-inflector (1.1.0)
     excon (0.112.0)
-    fog-brightbox (1.11.0)
+    fog-brightbox (1.12.0)
       dry-inflector
       fog-core (>= 1.45, < 3.0)
       fog-json

--- a/brightbox-cli.gemspec
+++ b/brightbox-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "fog-brightbox", ">= 1.11.0"
+  s.add_dependency "fog-brightbox", ">= 1.12.0"
   s.add_dependency "fog-core", "< 2.0"
   s.add_dependency "gli", "~> 2.21"
   s.add_dependency "highline", "~> 2.0"


### PR DESCRIPTION
This fixes a few issues related to very old or newest versions of Ruby and fallout from upstream dependency changes.