### PR TITLE
Add ACME support for `lba` commands

### DIFF
--- a/lib/brightbox-cli/commands/lbs/create.rb
+++ b/lib/brightbox-cli/commands/lbs/create.rb
@@ -32,15 +32,15 @@ module Brightbox
       c.default_value "/"
       c.flag [:s, "hc-request"]
 
-      c.desc "Healthcheck interval"
+      c.desc "Health check interval"
       c.default_value "5000"
       c.flag [:e, "hc-interval"]
 
-      c.desc "Healthcheck threshold up. Number of successful healthchecks for the node to be considered up."
+      c.desc "Health check threshold up. Number of successful health checks for the node to be considered up."
       c.default_value "3"
       c.flag [:u, "hc-up"]
 
-      c.desc "Healthcheck threshold down. Number of failed healthchecks for the node to be considered down."
+      c.desc "Health check threshold down. Number of failed health checks for the node to be considered down."
       c.default_value "3"
       c.flag [:d, "hc-down"]
 
@@ -100,7 +100,7 @@ module Brightbox
           end
         end
 
-        # SSL argumens
+        # SSL arguments
         ssl_cert_path = options["ssl-cert"]
         ssl_key_path = options["ssl-key"]
 
@@ -117,16 +117,18 @@ module Brightbox
 
         msg = "Creating a new load balancer"
         info msg
-        lb = LoadBalancer.create(:policy => options[:policy],
-                                 :name => options[:n],
-                                 :buffer_size => options[:b],
-                                 :healthcheck => healthcheck,
-                                 :listeners => listeners,
-                                 :certificate_pem => ssl_cert,
-                                 :certificate_private_key => ssl_key,
-                                 :ssl_minimum_version => options["ssl-min-ver"],
-                                 :sslv3 => options["sslv3"],
-                                 :nodes => nodes)
+        lb = LoadBalancer.create(
+          buffer_size: options[:b],
+          certificate_pem: ssl_cert,
+          certificate_private_key: ssl_key,
+          healthcheck: healthcheck,
+          listeners: listeners,
+          name: options[:n],
+          nodes: nodes,
+          policy: options[:policy],
+          ssl_minimum_version: options["ssl-min-ver"],
+          sslv3: options["sslv3"]
+        )
         render_table([lb], global_options)
       end
     end

--- a/lib/brightbox-cli/commands/lbs/create.rb
+++ b/lib/brightbox-cli/commands/lbs/create.rb
@@ -44,6 +44,9 @@ module Brightbox
       c.default_value "3"
       c.flag [:d, "hc-down"]
 
+      c.desc "ACME domains"
+      c.flag ["acme_domains"]
+
       c.desc "Filepath to the SSL certificate file to use."
       c.flag ["ssl-cert"]
 
@@ -82,6 +85,10 @@ module Brightbox
           options[:b] = options[:b].to_i
         end
 
+        if options["acme_domains"]
+          options["acme_domains"] = options["acme_domains"].split(",")
+        end
+
         hc_arg_lookup = {
           :k => :port,
           :y => :type,
@@ -118,6 +125,7 @@ module Brightbox
         msg = "Creating a new load balancer"
         info msg
         lb = LoadBalancer.create(
+          domains: options["acme_domains"],
           buffer_size: options[:b],
           certificate_pem: ssl_cert,
           certificate_private_key: ssl_key,

--- a/lib/brightbox-cli/commands/lbs/show.rb
+++ b/lib/brightbox-cli/commands/lbs/show.rb
@@ -16,6 +16,7 @@ module Brightbox
             created_at
             deleted_at
             policy
+            acme_domains
             ssl_minimum_version
             ssl_issuer
             ssl_subject

--- a/lib/brightbox-cli/commands/lbs/update.rb
+++ b/lib/brightbox-cli/commands/lbs/update.rb
@@ -37,6 +37,9 @@ module Brightbox
       c.desc "Healthcheck threshold down. Number of failed healthchecks for the node to be considered down."
       c.flag [:d, "hc-down"]
 
+      c.desc "ACME domains"
+      c.flag ["acme_domains"]
+
       c.desc "Filepath to the SSL certificate file to use."
       c.flag ["ssl-cert"]
 
@@ -130,6 +133,10 @@ module Brightbox
 
         if options["ssl-min-ver"] && !options["ssl-min-ver"].nil?
           lbopts[:ssl_minimum_version] = options["ssl-min-ver"]
+        end
+
+        if options["acme_domains"]
+          lbopts[:domains] = options["acme_domains"].split(",")
         end
 
         lbopts.nilify_blanks

--- a/lib/brightbox-cli/load_balancers.rb
+++ b/lib/brightbox-cli/load_balancers.rb
@@ -9,6 +9,18 @@ module Brightbox
       new(conn.load_balancers.create(options))
     end
 
+    def acme_domains
+      if attributes["acme"]
+        attributes["acme"]["domains"].map do |domain|
+          [domain["identifier"], domain["status"]].join(":")
+        end.join(",")
+      else
+        []
+      end
+    rescue StandardError
+      []
+    end
+
     def attributes
       fog_model.attributes
     end
@@ -16,6 +28,7 @@ module Brightbox
     def to_row
       attributes.merge(
         :locked => locked?,
+        :acme_domains => acme_domains,
         :ssl_minimum_version => ssl_minimum_version,
         :ssl_issuer => certificate_issuer,
         :ssl_subject => certificate_subject,

--- a/spec/commands/lbs/create_spec.rb
+++ b/spec/commands/lbs/create_spec.rb
@@ -26,7 +26,38 @@ describe "brightbox lbs" do
       let(:expected_args) { { nodes: [{ node: "srv-12345" }] } }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
+        {
+          "id": "lba-12345",
+          "nodes": [
+            {
+              "id": "srv-12345"
+            }
+          ]
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:post, "http://api.brightbox.localhost/1.0/load_balancers?account_id=acc-12345")
+          .with(:body => hash_including("nodes" => [{ "node" => "srv-12345" }]))
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "makes request" do
+        expect(Brightbox::LoadBalancer).to receive(:create).with(hash_including(expected_args)).and_call_original
+
+        expect(stderr).to eq("Creating a new load balancer\n")
+        expect(stdout).to include("lba-12345")
+      end
+    end
+
+    context "with required nodes arguments" do
+      let(:argv) { %w[lbs create srv-12345] }
+      let(:expected_args) { { nodes: [{ node: "srv-12345" }] } }
+
+      let(:json_response) do
+        <<~EOS
         {
           "id": "lba-12345",
           "nodes": [
@@ -57,7 +88,7 @@ describe "brightbox lbs" do
       let(:expected_args) { { nodes: [{ node: "srv-12345" }, { node: "srv-54321" }] } }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
         {
           "id": "lba-12345",
           "nodes": [
@@ -91,7 +122,7 @@ describe "brightbox lbs" do
       let(:expected_args) { { nodes: [{ node: "srv-12345" }], buffer_size: 1024 } }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
         {
           "id": "lba-12345",
           "buffer_size": 1024
@@ -118,7 +149,7 @@ describe "brightbox lbs" do
       let(:expected_args) { { ssl_minimum_version: "TLSv1.0" } }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
         {
           "id":"lba-12345",
           "ssl_minimum_version":"TLSv1.0"

--- a/spec/commands/lbs/show_spec.rb
+++ b/spec/commands/lbs/show_spec.rb
@@ -58,6 +58,18 @@ describe "brightbox lbs" do
           "name":"app-lb1",
           "status":"active",
           "created_at":"2012-03-05T12:00:00Z",
+          "acme": {
+            "domains": [
+              {
+                "identifier": "domain.test",
+                "status": "verified"
+              },
+              {
+                "identifier": "domain2.test",
+                "status": "verified"
+              }
+            ]
+          },
           "nodes":[
             {
               "id":"srv-12345",
@@ -81,6 +93,7 @@ describe "brightbox lbs" do
           expect(stdout).to include("name: app-lb1")
           expect(stdout).to include("created_at: 2012-03-05T12:00Z")
           expect(stdout).to include("nodes: srv-12345")
+          expect(stdout).to include("acme_domains: domain.test:verified,domain2.test:verified")
         end
       end
     end

--- a/spec/commands/lbs/show_spec.rb
+++ b/spec/commands/lbs/show_spec.rb
@@ -6,11 +6,82 @@ describe "brightbox lbs" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
-      let(:argv) { %w[lbs show] }
+    before do
+      config = config_from_contents(USER_APP_CONFIG_CONTENTS)
+      cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
+    end
 
-      it "does not error" do
-        expect { output }.to_not raise_error
+    context "without identifier argument" do
+      let(:argv) { %w[lbs show] }
+      let(:json_response) do
+        <<~EOS
+        [
+          {
+            "id":"lba-12345",
+            "name":"app-lb1",
+            "status":"active",
+            "created_at":"2012-03-05T12:00:00Z",
+            "nodes":[
+              {
+                "id":"srv-12345",
+                "status":"active"
+              }
+            ]
+          }
+        ]
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/load_balancers?account_id=acc-12345")
+          .to_return(:status => 200, :body => json_response)
+      end
+
+      it "shows load balancer details" do
+        aggregate_failures do
+          expect(stderr).to eq("")
+          expect(stdout).to include("id: lba-12345")
+          expect(stdout).to include("status: active")
+          expect(stdout).to include("name: app-lb1")
+          expect(stdout).to include("created_at: 2012-03-05T12:00Z")
+          expect(stdout).to include("nodes: srv-12345")
+        end
+      end
+    end
+
+    context "with identifier argument" do
+      let(:argv) { %w[lbs show lba-12345] }
+      let(:json_response) do
+        <<~EOS
+        {
+          "id":"lba-12345",
+          "name":"app-lb1",
+          "status":"active",
+          "created_at":"2012-03-05T12:00:00Z",
+          "nodes":[
+            {
+              "id":"srv-12345",
+              "status":"active"
+            }
+          ]
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/load_balancers/lba-12345?account_id=acc-12345")
+          .to_return(:status => 200, :body => json_response)
+      end
+
+      it "shows load balancer details" do
+        aggregate_failures do
+          expect(stderr).to eq("")
+          expect(stdout).to include("id: lba-12345")
+          expect(stdout).to include("status: active")
+          expect(stdout).to include("name: app-lb1")
+          expect(stdout).to include("created_at: 2012-03-05T12:00Z")
+          expect(stdout).to include("nodes: srv-12345")
+        end
       end
     end
   end

--- a/spec/commands/lbs/update_spec.rb
+++ b/spec/commands/lbs/update_spec.rb
@@ -99,5 +99,49 @@ describe "brightbox lbs" do
         expect(stdout).to include("lba-kl432")
       end
     end
+
+    context "--acme-domains=example.com" do
+      let(:argv) { ["lbs", "update", "--acme-domains", "example.com", "--listeners", "443:443:https:5000", "lba-12345"] }
+      let(:json_response) do
+        <<~EOS
+        {
+          "id":"lba-12345",
+          "acme": {
+            "domains": [
+              {
+                "identifier": "example.com",
+                "last_message": null,
+                "status": "pending"
+              }
+            ]
+          },
+          "certificate": null,
+          "listeners": [
+            {
+              "in": 443,
+              "out": 443,
+              "protocol": "https",
+              "proxy_protocol": null,
+              "timeout": 5000
+            }
+          ]
+        }
+        EOS
+      end
+
+      before do
+        stub_request(:get, "http://api.brightbox.localhost/1.0/load_balancers/lba-12345?account_id=acc-12345")
+          .to_return(:status => 200, :body => '{"id":"lba-12345"}')
+
+        stub_request(:put, "http://api.brightbox.localhost/1.0/load_balancers/lba-12345?account_id=acc-12345")
+          .with(body: hash_including(domains: ["example.com"]))
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "includes acme_certificate_domain in response" do
+        expect(stderr).to eq("Updating load balancer lba-12345\n")
+        expect(stdout).to include("lba-12345")
+      end
+    end
   end
 end

--- a/spec/commands/lbs/update_spec.rb
+++ b/spec/commands/lbs/update_spec.rb
@@ -23,7 +23,7 @@ describe "brightbox lbs" do
       let(:argv) { ["lbs", "update", "--ssl-min-ver", "TLSv1.0", "lba-12345"] }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
         {
           "id":"lba-12345",
           "ssl_minimum_version":"TLSv1.0"
@@ -50,7 +50,7 @@ describe "brightbox lbs" do
       let(:argv) { ["lbs", "update", "--sslv3", "lba-grt24"] }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
         {
           "id":"lba-grt24",
           "ssl_minimum_version":"TLSv1.0"
@@ -77,7 +77,7 @@ describe "brightbox lbs" do
       let(:argv) { ["lbs", "update", "--no-sslv3", "lba-kl432"] }
 
       let(:json_response) do
-        <<-EOS
+        <<~EOS
         {
           "id":"lba-kl432",
           "ssl_minimum_version":"TLSv1.0"


### PR DESCRIPTION
 Passing a list of comma separated domains to either `lbs create` or `lbs
update` will request that domains are provisioned from Let's Encrypt.
    
For this to work a `https` (not `tcp`) listener needs to be available on
port 443 otherwise the request will be rejected.
    
    brightbox lbs create --acme-domains domain.example --listeners 443:443:https:5000 srv-12345
    
Domains and their status are listed under the `lbs show` command output.