### PR TITLE
Remove requirement for one load balancer node

### DIFF
--- a/lib/brightbox-cli/commands/lbs/create.rb
+++ b/lib/brightbox-cli/commands/lbs/create.rb
@@ -61,8 +61,6 @@ module Brightbox
       c.switch ["sslv3"]
 
       c.action do |global_options, options, args|
-        raise "You must specify which servers to balance connections to" if args.empty?
-
         listeners = options[:l].split(",").map do |l|
           inport, outport, protocol, timeout = l.split ":"
           raise "listener '#{l}' is invalid" if inport.nil? || outport.nil? || protocol.nil?

--- a/spec/commands/lbs/create_spec.rb
+++ b/spec/commands/lbs/create_spec.rb
@@ -11,17 +11,34 @@ describe "brightbox lbs" do
       cache_access_token(config, "f83da712e6299cda953513ec07f7a754f747d727")
     end
 
-    context "without required nodes arguments" do
+    context "without nodes arguments" do
       let(:argv) { %w[lbs create] }
+      let(:expected_args) { { nodes: [] } }
 
-      it "does not error" do
-        expect { output }.to_not raise_error
+      let(:json_response) do
+        <<~EOS
+        {
+          "id": "lba-12345",
+          "nodes": []
+        }
+        EOS
+      end
 
-        expect(stderr).to eq("ERROR: You must specify which servers to balance connections to\n")
+      before do
+        stub_request(:post, "http://api.brightbox.localhost/1.0/load_balancers?account_id=acc-12345")
+          .with(:body => hash_including("nodes" => []))
+          .to_return(:status => 202, :body => json_response)
+      end
+
+      it "makes request" do
+        expect(Brightbox::LoadBalancer).to receive(:create).with(hash_including(expected_args)).and_call_original
+
+        expect(stderr).to eq("Creating a new load balancer\n")
+        expect(stdout).to include("lba-12345")
       end
     end
 
-    context "with required nodes arguments" do
+    context "with a nodes argument" do
       let(:argv) { %w[lbs create srv-12345] }
       let(:expected_args) { { nodes: [{ node: "srv-12345" }] } }
 
@@ -52,38 +69,7 @@ describe "brightbox lbs" do
       end
     end
 
-    context "with required nodes arguments" do
-      let(:argv) { %w[lbs create srv-12345] }
-      let(:expected_args) { { nodes: [{ node: "srv-12345" }] } }
-
-      let(:json_response) do
-        <<~EOS
-        {
-          "id": "lba-12345",
-          "nodes": [
-            {
-              "id": "srv-12345"
-            }
-          ]
-        }
-        EOS
-      end
-
-      before do
-        stub_request(:post, "http://api.brightbox.localhost/1.0/load_balancers?account_id=acc-12345")
-          .with(:body => hash_including("nodes" => [{ "node" => "srv-12345" }]))
-          .to_return(:status => 202, :body => json_response)
-      end
-
-      it "makes request" do
-        expect(Brightbox::LoadBalancer).to receive(:create).with(hash_including(expected_args)).and_call_original
-
-        expect(stderr).to eq("Creating a new load balancer\n")
-        expect(stdout).to include("lba-12345")
-      end
-    end
-
-    context "with multiple nodes" do
+    context "with multiple node arguments" do
       let(:argv) { %w[lbs create srv-12345 srv-54321] }
       let(:expected_args) { { nodes: [{ node: "srv-12345" }, { node: "srv-54321" }] } }
 


### PR DESCRIPTION
The API previously enforced a minimum of one server to be balanced and that was encoded in the CLI. The technical requirement for that has long since gone and the API no longer enforces it.

This removes it so load balancers without nodes can now be created.