### PR TITLE
Pass `DEBUG=true` to CI specs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
-
+    env:
+      DEBUG: "true"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}


### PR DESCRIPTION
To prevent regressions when examples assume STDERR is empty but passing `DEBUG` will output addition text and fail it, this sets it in the CI environments to catch it during testing and not months later under manual testing.