### PR TITLE
Coverage was not tracking a number of files

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,22 @@
+require "simplecov"
+
+SimpleCov.start do
+  add_filter "/spec/"
+  add_filter "/config/"
+  add_filter "/vendor/"
+
+  track_files "{lib}/**/*.rb"
+
+  # Currently just above 75% coverage - don't make it worse
+  minimum_coverage 75
+  refuse_coverage_drop
+end
+
 LIB_DIR = File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
 
 $LOAD_PATH.unshift LIB_DIR unless
   $LOAD_PATH.include?(LIB_DIR) || $LOAD_PATH.include?(File.expand_path(LIB_DIR))
 
-require "simplecov"
 require "brightbox_cli"
 require "json"
 require "tmpdir"
@@ -30,16 +43,6 @@ TEST_RUNNER_HOME = ENV.fetch("HOME", nil)
 Fog.timeout = 10
 
 require "fog/brightbox"
-
-SimpleCov.start do
-  add_filter "/spec/"
-  add_filter "/config/"
-  add_filter "/vendor/"
-
-  # Currently just above 80% coverage - don't make it worse
-  minimum_coverage 80
-  refuse_coverage_drop
-end
 
 RSpec.configure do |config|
   config.include CommonHelpers


### PR DESCRIPTION
A number of underlying superclasses were not discovered by the autoloading setup in use resulting in missing entries and a drop in overall coverage to 76%.

This changes the the setup to ensure things like `api.rb` are covered.