### PR TITLE
Refactor `attributes` and `to_row`

### DIFF
--- a/lib/brightbox-cli/accounts.rb
+++ b/lib/brightbox-cli/accounts.rb
@@ -13,7 +13,11 @@ module Brightbox
     end
 
     def to_row
-      attributes.merge(:ram_free => ram_free, :cloud_ip_limit => cloud_ip_limit, :lb_limit => lb_limit)
+      attributes.to_h.merge(
+        :ram_free => ram_free,
+        :cloud_ip_limit => cloud_ip_limit,
+        :lb_limit => lb_limit
+      )
     end
 
     def self.all

--- a/lib/brightbox-cli/api.rb
+++ b/lib/brightbox-cli/api.rb
@@ -72,6 +72,10 @@ module Brightbox
       false
     end
 
+    def to_row
+      attributes.to_h
+    end
+
     def to_s
       @id
     end
@@ -175,7 +179,7 @@ module Brightbox
       if value
         value
       else
-        Brightbox.config.cache_id id
+        Brightbox.config.cache_id id if Brightbox.config.respond_to?(:cache_id)
         @cache[id] = get(id)
       end
     end

--- a/lib/brightbox-cli/cloud_ips.rb
+++ b/lib/brightbox-cli/cloud_ips.rb
@@ -33,15 +33,15 @@ module Brightbox
     end
 
     def attributes
-      a = fog_model.attributes
-      a[:destination] = destination_id
-      a
+      fog_attributes.tap do |attrs|
+        attrs[:destination] = destination_id
+      end
     end
 
     def to_row
-      o = attributes
-      o[:port_translators] = translators(o)
-      o
+      attributes.merge(
+        port_translators: translators(attributes),
+      ).to_h
     end
 
     def mapped?

--- a/lib/brightbox-cli/collaboration.rb
+++ b/lib/brightbox-cli/collaboration.rb
@@ -31,14 +31,10 @@ module Brightbox
 
     attr_reader :id
 
-    def attributes
-      fog_model.attributes
-    end
-
     def to_row
-      row_attributes = attributes
-      row_attributes[:name] = invitee_name
-      row_attributes
+      attributes.merge(
+        name: invitee_name
+      ).to_h
     end
 
     def invitee_name

--- a/lib/brightbox-cli/database_server.rb
+++ b/lib/brightbox-cli/database_server.rb
@@ -70,34 +70,34 @@ module Brightbox
     end
 
     def type_identifier
-      return unless fog_model.attributes.key?("database_server_type")
+      return unless fog_attributes.key?("database_server_type")
 
-      fog_model.attributes["database_server_type"]["id"]
+      fog_attributes["database_server_type"]["id"]
     end
 
     def zone_handle
-      return unless fog_model.attributes.key?("zone")
+      return unless fog_attributes.key?("zone")
 
-      fog_model.attributes["zone"]["handle"]
+      fog_attributes["zone"]["handle"]
     end
 
     def to_row
-      a = fog_model.attributes
-      a[:status] = fog_model.state
-      a[:locked] = locked?
-      a[:type] = type_identifier
-      a[:db_engine] = engine_version
-      a[:engine] = database_engine
-      a[:version] = database_version
-      a[:maintenance_weekday] = maintenance_weekday
-      a[:maintenance_hour] = maintenance_hour
-      a[:maintenance_window] = maintenance_window
-      a[:zone] = zone_handle
-      a[:created_on] = created_on
-      a[:allow_access] = allow_access
-      a[:cloud_ip_ids] = cloud_ip_ids
-      a[:cloud_ips] = cloud_ip_addresses
-      a
+      attributes.merge(
+        status: fog_model.state,
+        locked: locked?,
+        type: type_identifier,
+        db_engine: engine_version,
+        engine: database_engine,
+        version: database_version,
+        maintenance_weekday: maintenance_weekday,
+        maintenance_hour: maintenance_hour,
+        maintenance_window: maintenance_window,
+        zone: zone_handle,
+        created_on: created_on,
+        allow_access: allow_access,
+        cloud_ip_ids: cloud_ip_ids,
+        cloud_ips: cloud_ip_addresses
+      )
     end
 
     def engine_version

--- a/lib/brightbox-cli/database_snapshot.rb
+++ b/lib/brightbox-cli/database_snapshot.rb
@@ -27,11 +27,11 @@ module Brightbox
     end
 
     def to_row
-      a = fog_model.attributes
-      a[:status] = fog_model.state
-      a[:locked] = locked?
-      a[:created_on] = fog_model.created_at.strftime("%Y-%m-%d")
-      a
+      fog_attributes.merge(
+        status: fog_model.state,
+        locked: locked?,
+        created_on: fog_model.created_at.strftime("%Y-%m-%d")
+      )
     end
   end
 end

--- a/lib/brightbox-cli/database_type.rb
+++ b/lib/brightbox-cli/database_type.rb
@@ -3,10 +3,10 @@ module Brightbox
     def self.require_account?; true; end
 
     def attributes
-      o = fog_model.attributes
-      o[:ram] = ram
-      o[:disk] = disk
-      o
+      fog_attributes.tap do |attrs|
+        attrs[:ram] = ram
+        attrs[:disk] = disk
+      end
     end
 
     def ram
@@ -15,10 +15,6 @@ module Brightbox
 
     def disk
       fog_model.disk.to_i
-    end
-
-    def to_row
-      attributes
     end
 
     def self.all

--- a/lib/brightbox-cli/detailed_server.rb
+++ b/lib/brightbox-cli/detailed_server.rb
@@ -1,40 +1,38 @@
 module Brightbox
   class DetailedServer < Server
     def to_row
-      row_attributes = attributes
+      attributes.tap do |attrs|
+        attrs[:compatibility_mode] = attrs["compatibility_mode"]
 
-      row_attributes[:compatibility_mode] = row_attributes["compatibility_mode"]
+        if server_type
+          attrs[:type] = server_type["id"]
+          attrs[:type_handle] = server_type["handle"]
+          attrs[:type_name] = server_type["name"]
+          attrs[:ram] = server_type["ram"]
+          attrs[:cores] = server_type["cores"]
+          attrs[:disk] = server_type["disk_size"].to_i
+        end
 
-      if server_type
-        row_attributes[:type] = server_type["id"]
-        row_attributes[:type_handle] = server_type["handle"]
-        row_attributes[:type_name] = server_type["name"]
-        row_attributes[:ram] = server_type["ram"]
-        row_attributes[:cores] = server_type["cores"]
-        row_attributes[:disk] = server_type["disk_size"].to_i
-      end
+        if image
+          attrs[:image_name] = image.name
+          attrs[:arch] = image.arch
+          attrs[:image_username] = image.username
+        end
 
-      if image
-        row_attributes[:image_name] = image.name
-        row_attributes[:arch] = image.arch
-        row_attributes[:image_username] = image.username
-      end
+        attrs[:private_ips] = interfaces.map { |i| i["ipv4_address"] }.join(", ")
+        attrs[:ipv6_address] = interfaces.map { |i| i["ipv6_address"] }.join(", ")
 
-      row_attributes[:private_ips] = interfaces.map { |i| i["ipv4_address"] }.join(", ")
-      row_attributes[:ipv6_address] = interfaces.map { |i| i["ipv6_address"] }.join(", ")
+        attrs[:cloud_ip_ids] = cloud_ips.map { |i| i["id"] }.join(", ")
+        attrs[:cloud_ipv4s] = cloud_ips.map { |i| i["public_ipv4"] }.join(", ")
+        attrs[:cloud_ipv6s] = cloud_ips.map { |i| i["public_ipv6"] }.join(", ")
+        attrs[:snapshots] = snapshots.map { |i| i["id"] }.join(", ")
 
-      row_attributes[:cloud_ip_ids] = cloud_ips.map { |i| i["id"] }.join(", ")
-      row_attributes[:cloud_ipv4s] = cloud_ips.map { |i| i["public_ipv4"] }.join(", ")
-      row_attributes[:cloud_ipv6s] = cloud_ips.map { |i| i["public_ipv6"] }.join(", ")
-      row_attributes[:snapshots] = snapshots.map { |i| i["id"] }.join(", ")
+        if server_groups
+          attrs[:server_groups] = server_groups.map { |sg| sg["id"] }.join(", ")
+        end
 
-      if server_groups
-        row_attributes[:server_groups] = server_groups.map { |sg| sg["id"] }.join(", ")
-      end
-
-      row_attributes[:volumes] = volume_ids if volumes
-
-      row_attributes
+        attrs[:volumes] = volume_ids if volumes
+      end.to_h
     end
 
     def volume_ids

--- a/lib/brightbox-cli/detailed_server_group.rb
+++ b/lib/brightbox-cli/detailed_server_group.rb
@@ -1,9 +1,9 @@
 module Brightbox
   class DetailedServerGroup < ServerGroup
     def to_row
-      row_attributes = super
+      row_attributes = attributes
       row_attributes[:firewall_policy] = firewall_policy && firewall_policy.id
-      row_attributes
+      row_attributes.to_h
     end
 
     def self.default_field_order

--- a/lib/brightbox-cli/firewall_policy.rb
+++ b/lib/brightbox-cli/firewall_policy.rb
@@ -15,15 +15,11 @@ module Brightbox
     end
 
     def attributes
-      t = fog_model.attributes
-      t[:name] = name
-      t[:description] = description
-      t[:server_group] = server_group_id
-      t
-    end
-
-    def to_row
-      attributes
+      fog_attributes.tap do |attrs|
+        attrs[:name] = name
+        attrs[:description] = description
+        attrs[:server_group] = server_group_id
+      end
     end
 
     def self.default_field_order

--- a/lib/brightbox-cli/firewall_rule.rb
+++ b/lib/brightbox-cli/firewall_rule.rb
@@ -19,24 +19,23 @@ module Brightbox
     end
 
     def attributes
-      t = @attributes || fog_model.attributes
-      t[:sport] = t[:source_port]
-      t[:dport] = t[:destination_port]
-      t[:firewall_policy] = t[:firewall_policy_id]
-      t[:icmp_type] = t[:icmp_type_name]
-      t
+      (@attributes || fog_attributes).tap do |attrs|
+        attrs[:sport] = attrs[:source_port]
+        attrs[:dport] = attrs[:destination_port]
+        attrs[:firewall_policy] = attrs[:firewall_policy_id]
+        attrs[:icmp_type] = attrs[:icmp_type_name]
+      end
     end
 
     def to_row
-      attrs = attributes.dup
-      %i[protocol source sport destination dport icmp_type].each do |key|
-        attrs[key] = attributes[key] || "-"
-      end
-      attrs
-    end
-
-    def ret_val(attributes, key)
-      attributes[key] || "-"
+      attributes.merge(
+        protocol: attributes[:protocol] || "-",
+        source: attributes[:source] || "-",
+        sport: attributes[:sport] || "-",
+        destination: attributes[:destination] || "-",
+        dport: attributes[:dport] || "-",
+        icmp_type: attributes[:icmp_type] || "-"
+      )
     end
 
     def self.default_field_order

--- a/lib/brightbox-cli/images.rb
+++ b/lib/brightbox-cli/images.rb
@@ -68,33 +68,32 @@ module Brightbox
     end
 
     def status
-      if fog_model.attributes[:status] == "available"
+      if fog_attributes[:status] == "available"
         public? ? "public" : "private"
-      elsif fog_model.attributes[:status] == "deprecated"
+      elsif fog_attributes[:status] == "deprecated"
         public? ? "deprecated" : "private"
       else
-        fog_model.attributes[:status]
+        fog_attributes[:status]
       end
     end
 
     def to_row
-      o = fog_model.attributes
-      o[:id] = fog_model.id
-      o[:status] = status
-      o[:locked] = locked?
-      o[:username] = username
-      o[:arch] = arch
-      o[:name] = name.to_s + " (#{arch})"
-      o[:owner] = owner_id
-      o[:owner] = "brightbox" if official
-      o[:type] = type
-      o[:created_at] = created_at
-      o[:created_on] = created_on
-      o[:description] = description if description
-      o[:licence_name] = licence_name
-      o[:size] = virtual_size
-      o[:min_ram] = min_ram
-      o
+      fog_attributes.merge(
+        id: fog_model.id,
+        status: status,
+        locked: locked?,
+        username: username,
+        arch: arch,
+        name: name.to_s + " (#{arch})",
+        owner: official ? "brightbox" : owner_id,
+        type: type,
+        created_at: created_at,
+        created_on: created_on,
+        description: description,
+        licence_name: licence_name,
+        size: virtual_size,
+        min_ram: min_ram
+      )
     end
 
     def public?
@@ -102,7 +101,7 @@ module Brightbox
     end
 
     def status_sort_code
-      case fog_model.attributes[:status]
+      case fog_attributes[:status]
       when "available"
         (public? ? 1 : 2)
       when "deprecated"

--- a/lib/brightbox-cli/indifferent_access_hash.rb
+++ b/lib/brightbox-cli/indifferent_access_hash.rb
@@ -17,7 +17,7 @@ class IndifferentAccessHash
   # @param value [Object] the value to set
   # @return [Object] the value of the key
   def []=(key, value)
-    @hash[key.to_s] = value
+    @hash[key.to_sym] = value
   end
 
   # @param other [Object] the object to compare

--- a/lib/brightbox-cli/load_balancers.rb
+++ b/lib/brightbox-cli/load_balancers.rb
@@ -21,10 +21,6 @@ module Brightbox
       []
     end
 
-    def attributes
-      fog_model.attributes
-    end
-
     def to_row
       attributes.merge(
         :locked => locked?,

--- a/lib/brightbox-cli/server_groups.rb
+++ b/lib/brightbox-cli/server_groups.rb
@@ -34,15 +34,11 @@ module Brightbox
       fog_model.destroy
     end
 
-    def attributes
-      fog_model.attributes
-    end
-
     def to_row
-      o = attributes
-      o[:servers] = server_string
-      o[:server_count] = server_count
-      o
+      super.merge(
+        servers: server_string,
+        server_count: server_count
+      ).to_h
     end
 
     def server_ids

--- a/lib/brightbox-cli/types.rb
+++ b/lib/brightbox-cli/types.rb
@@ -3,10 +3,10 @@ module Brightbox
     def self.require_account?; true; end
 
     def attributes
-      o = fog_model.attributes
-      o[:ram] = ram
-      o[:disk] = disk
-      o
+      fog_attributes.tap do |attrs|
+        attrs[:ram] = ram
+        attrs[:disk] = disk
+      end
     end
 
     def ram
@@ -15,10 +15,6 @@ module Brightbox
 
     def disk
       fog_model.disk.to_i
-    end
-
-    def to_row
-      attributes
     end
 
     def render_cell

--- a/lib/brightbox-cli/user_collaboration.rb
+++ b/lib/brightbox-cli/user_collaboration.rb
@@ -69,7 +69,7 @@ module Brightbox
     def to_row
       row_attributes = attributes
       row_attributes[:account] = attributes[:account]["id"]
-      row_attributes
+      row_attributes.to_h
     end
   end
 end

--- a/lib/brightbox-cli/users.rb
+++ b/lib/brightbox-cli/users.rb
@@ -1,11 +1,9 @@
 module Brightbox
   class User < Api
-    def attributes
-      fog_model.attributes
-    end
-
     def to_row
-      attributes.merge(:accounts => accounts.size)
+      attributes.merge(
+        accounts: accounts.size
+      )
     end
 
     def self.all

--- a/lib/brightbox-cli/volume.rb
+++ b/lib/brightbox-cli/volume.rb
@@ -57,19 +57,15 @@ module Brightbox
     end
 
     def attributes
-      a = fog_model.attributes
-      a[:id] = fog_model.id
-      a[:image] = image_id
-      a[:locked] = locked?
-      a[:server] = server_id
-      a[:status] = state
-      a[:type] = storage_type
-      a[:zone] = zone_id
-      a
-    end
-
-    def to_row
-      attributes
+      super.merge(
+        id: fog_model.id,
+        image: image_id,
+        locked: locked?,
+        server: server_id,
+        status: state,
+        type: storage_type,
+        zone: zone_id
+      )
     end
 
     def update(options)

--- a/lib/brightbox-cli/zones.rb
+++ b/lib/brightbox-cli/zones.rb
@@ -2,10 +2,6 @@ module Brightbox
   class Zone < Api
     def self.require_account?; true; end
 
-    def to_row
-      attributes
-    end
-
     def self.all
       conn.zones
     end

--- a/spec/support/shared/api_resource_examples.rb
+++ b/spec/support/shared/api_resource_examples.rb
@@ -9,7 +9,32 @@ shared_examples "a wrapped API resource" do
   it { is_expected.to respond_to(:to_row) }
 
   it { is_expected.to respond_to(:to_s) }
+
   it "#to_s equals the #id" do
     expect(subject.to_s).to eql(subject.id)
   end
+
+  # describe "#attributes" do
+  #   subject { described_class.new(fog_model) }
+
+  #   let(:fog_model) do
+  #     double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  #   end
+
+  #   it "returns an IndifferentAccessHash" do
+  #     expect(subject.attributes).to be_a(IndifferentAccessHash)
+  #   end
+  # end
+
+  # describe "#to_row" do
+  #   subject { described_class.new(fog_model) }
+
+  #   let(:fog_model) do
+  #     double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  #   end
+
+  #   it "returns a Hash to avoid hirb errors" do
+  #     expect(subject.to_row).to be_a(Hash)
+  #   end
+  # end
 end

--- a/spec/unit/brightbox/account/attributes_spec.rb
+++ b/spec/unit/brightbox/account/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::Account, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/cloud_ip/attributes_spec.rb
+++ b/spec/unit/brightbox/cloud_ip/attributes_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::CloudIP, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "cip-12345",
+      destination_id: nil,
+      attributes: model_attributes
+    )
+  end
+  let(:model_attributes) { { id: "cip-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/collaborating_account/attributes_spec.rb
+++ b/spec/unit/brightbox/collaborating_account/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::CollaboratingAccount, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/database_server/attributes_spec.rb
+++ b/spec/unit/brightbox/database_server/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::DatabaseServer, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/database_snapshot/attributes_spec.rb
+++ b/spec/unit/brightbox/database_snapshot/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::DatabaseSnapshot, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/database_type/attributes_spec.rb
+++ b/spec/unit/brightbox/database_type/attributes_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::DatabaseType, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "typ-12345",
+      attributes: model_attributes,
+      ram: 1024,
+      disk: 10_240,
+    )
+  end
+  let(:model_attributes) { { id: "typ-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/detailed_server/attributes_spec.rb
+++ b/spec/unit/brightbox/detailed_server/attributes_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::DetailedServer, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "srv-12345",
+      attributes: model_attributes,
+      cloud_ips: [],
+      created_at: Time.parse("2025-01-01T12:00:00Z"),
+      created_on: "2025-01-01",
+      hostname: "srv-12345.gb1.brightbox.com",
+      image_id: "img-12345",
+      interfaces: [],
+      locked?: false,
+      type: "typ-12345",
+      state: "active",
+      server_type: "typ-12345",
+      zone: { id: "zon-12345", handle: "gb1-a" }
+    )
+  end
+  let(:model_attributes) { { id: "srv-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/detailed_server_group/attributes_spec.rb
+++ b/spec/unit/brightbox/detailed_server_group/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::DetailedServerGroup, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/firewall_policy/attributes_spec.rb
+++ b/spec/unit/brightbox/firewall_policy/attributes_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::FirewallPolicy, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "res-12345",
+      attributes: model_attributes,
+      description: "",
+      server_group_id: "grp-12345",
+      name: "my-policy"
+    )
+  end
+  let(:model_attributes) { { id: "fwp-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/firewall_rule/attributes_spec.rb
+++ b/spec/unit/brightbox/firewall_rule/attributes_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::FirewallRule, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "fwr-12345",
+      attributes: model_attributes
+    )
+  end
+  let(:model_attributes) { { id: "fwr-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/image/attributes_spec.rb
+++ b/spec/unit/brightbox/image/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::Image, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/load_balancer/attributes_spec.rb
+++ b/spec/unit/brightbox/load_balancer/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::LoadBalancer, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/server/attributes_spec.rb
+++ b/spec/unit/brightbox/server/attributes_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::Server, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "srv-12345",
+      attributes: model_attributes,
+      cloud_ips: [],
+      created_at: Time.parse("2025-01-01T12:00:00Z"),
+      created_on: "2025-01-01",
+      hostname: "srv-12345.gb1.brightbox.com",
+      image_id: "img-12345",
+      interfaces: [],
+      locked?: false,
+      type: "typ-12345",
+      state: "active",
+      server_type: "typ-12345",
+      zone: { id: "zon-12345", handle: "gb1-a" }
+    )
+  end
+  let(:model_attributes) { { id: "srv-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/server_group/attributes_spec.rb
+++ b/spec/unit/brightbox/server_group/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::ServerGroup, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/type/attributes_spec.rb
+++ b/spec/unit/brightbox/type/attributes_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::Type, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double(
+      "Fog::Model",
+      id: "typ-12345",
+      attributes: model_attributes,
+      ram: 1_024,
+      disk: 10_240
+    )
+  end
+  let(:model_attributes) { { id: "typ-12345" } }
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/user/attributes_spec.rb
+++ b/spec/unit/brightbox/user/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::User, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end

--- a/spec/unit/brightbox/user_collaboration/attributes_spec.rb
+++ b/spec/unit/brightbox/user_collaboration/attributes_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Brightbox::UserCollaboration, "#attributes" do
+  subject { described_class.new(fog_model) }
+
+  let(:fog_model) do
+    double("Fog::Model", id: "res-12345", attributes: { id: "res-12345"})
+  end
+
+  it "returns an IndifferentAccessHash" do
+    expect(subject.attributes).to be_a(IndifferentAccessHash)
+  end
+end


### PR DESCRIPTION
We should be using the superclass version of these rather than repeating the same reference repeatedly.

Since `Api#attributes` returns an `IndifferentAccessHash` which the `hirb` table code fails with, it is better to use `#merge` to assemble the table `#to_row` contents.