### PR TITLE
Fix incorrectly implemented `show` commands

### DIFF
--- a/lib/brightbox-cli/commands/images/show.rb
+++ b/lib/brightbox-cli/commands/images/show.rb
@@ -4,7 +4,11 @@ module Brightbox
     cmd.arg_name "image-id..."
     cmd.command [:show] do |c|
       c.action do |global_options, _options, args|
-        images = Image.find_all_or_warn(args)
+        raise "You must specify image IDs to show" if args.empty?
+
+        images = Image.find_or_call(args) do |id|
+          raise "Couldn't find an image with ID #{id}"
+        end
 
         display_options = {
           :vertical => true,

--- a/lib/brightbox-cli/commands/lbs/show.rb
+++ b/lib/brightbox-cli/commands/lbs/show.rb
@@ -4,7 +4,11 @@ module Brightbox
     cmd.arg_name "lbs-id..."
     cmd.command [:show] do |c|
       c.action do |global_options, _options, args|
-        lbs = LoadBalancer.find_all_or_warn(args)
+        raise "You must specify load balancer IDs to show" if args.empty?
+
+        lbs = LoadBalancer.find_or_call(args) do |id|
+          raise "Couldn't find a load balancer with ID #{id}"
+        end
 
         table_opts = global_options.merge(
           :vertical => true,

--- a/lib/brightbox-cli/commands/servers/show.rb
+++ b/lib/brightbox-cli/commands/servers/show.rb
@@ -4,7 +4,11 @@ module Brightbox
     cmd.arg_name "server-id..."
     cmd.command [:show] do |c|
       c.action do |global_options, _options, args|
-        servers = DetailedServer.find_all_or_warn(args)
+        raise "You must specify server IDs to show" if args.empty?
+
+        servers = DetailedServer.find_or_call(args) do |id|
+          raise "Couldn't find a server with ID #{id}"
+        end
 
         table_opts = global_options.merge(:vertical => true)
         render_table(servers, table_opts)

--- a/lib/brightbox-cli/commands/users/show.rb
+++ b/lib/brightbox-cli/commands/users/show.rb
@@ -4,7 +4,11 @@ module Brightbox
     cmd.arg_name "user-id..."
     cmd.command [:show] do |c|
       c.action do |global_options, _options, args|
-        users = User.find_all_or_warn(args)
+        raise "You must specify user IDs to show" if args.empty?
+
+        users = User.find_or_call(args) do |id|
+          raise "Couldn't find a user with ID #{id}"
+        end
 
         table_opts = global_options.merge(
           :vertical => true,

--- a/lib/brightbox-cli/commands/volumes/show.rb
+++ b/lib/brightbox-cli/commands/volumes/show.rb
@@ -5,7 +5,11 @@ module Brightbox
 
     cmd.command [:show] do |c|
       c.action do |global_options, _options, args|
-        volumes = Volume.find_all_or_warn(args)
+        raise "You must specify volume IDs to show" if args.empty?
+
+        volumes = Volume.find_or_call(args) do |id|
+          raise "Couldn't find a volume with ID #{id}"
+        end
 
         table_opts = global_options.merge(
           :vertical => true,

--- a/spec/commands/images/show_spec.rb
+++ b/spec/commands/images/show_spec.rb
@@ -17,28 +17,17 @@ RSpec.describe "brightbox images" do
     context "without arguments" do
       let(:argv) { %w[images show] }
 
-      before do
-        stub_request(:get, "#{api_url}/1.0/images?account_id=acc-12345")
-          .to_return(
-            status: 200,
-            body: [
-              {
-                id: "img-12345"
-              }
-            ].to_json
-          )
-      end
-
-      it "does not error" do
+      it "reports missing IDs" do
         expect { output }.to_not raise_error
 
-        expect(stderr).to match("")
-        expect(stderr).not_to match("ERROR")
-        expect(stdout).to match("img-12345")
+        aggregate_failures do
+          expect(stderr).to match("ERROR: You must specify image IDs to show")
+          expect(stdout).to eq("")
+        end
       end
     end
 
-    context "with identifier" do
+    context "with identifier argument" do
       let(:argv) { %w[images show img-11111] }
 
       before do
@@ -59,11 +48,52 @@ RSpec.describe "brightbox images" do
       it "does not error" do
         expect { output }.to_not raise_error
 
-        expect(stderr).to match("")
-        expect(stderr).not_to match("ERROR")
-        expect(stdout).to match("img-11111")
+        aggregate_failures do
+          expect(stderr).to match("")
+          expect(stderr).not_to match("ERROR")
+          expect(stdout).to match("img-11111")
 
-        expect(stdout).to match("min_ram: 2048")
+          expect(stdout).to match("min_ram: 2048")
+        end
+      end
+    end
+
+    context "with multiple identifiers" do
+      let(:argv) { %w[images show img-11111 img-22222] }
+
+      before do
+        stub_request(:get, "#{api_url}/1.0/images/img-11111?account_id=acc-12345")
+          .to_return(
+            status: 200,
+            body: {
+              id: "img-11111",
+              min_ram: 2_048
+            }.to_json
+          )
+
+        stub_request(:get, "#{api_url}/1.0/images/img-22222?account_id=acc-12345")
+          .to_return(
+            status: 200,
+            body: {
+              id: "img-22222",
+              min_ram: 4_096
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        aggregate_failures do
+          expect(stderr).to match("")
+          expect(stderr).not_to match("ERROR")
+
+          expect(stdout).to match("img-11111")
+          expect(stdout).to match("min_ram: 2048")
+
+          expect(stdout).to match("img-22222")
+          expect(stdout).to match("min_ram: 4096")
+        end
       end
     end
   end

--- a/spec/commands/servers/show_spec.rb
+++ b/spec/commands/servers/show_spec.rb
@@ -6,11 +6,93 @@ describe "brightbox servers" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      WebMock.reset!
+
+      config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+      stub_client_token_request
+      Brightbox.config.reauthenticate
+    end
+
+    context "without arguments" do
       let(:argv) { %w[servers show] }
 
-      it "does not error" do
+      it "reports missing IDs" do
         expect { output }.to_not raise_error
+
+        aggregate_failures do
+          expect(stderr).to match("ERROR: You must specify server IDs to show")
+          expect(stdout).to be_empty
+        end
+      end
+    end
+
+    context "with identifier argument" do
+      let(:argv) { %w[servers show srv-55555] }
+
+      before do
+        stub_request(:get, "#{api_url}/1.0/images")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              images: [
+                {
+                  id: "img-12345",
+                  min_ram: 2_048
+                }
+              ]
+            }.to_json
+          )
+
+        stub_request(:get, "#{api_url}/1.0/images/img-12345")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "img-12345"
+            }.to_json
+          )
+
+        stub_request(:get, "#{api_url}/1.0/servers/srv-55555")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "srv-12345",
+              name: "app-server1",
+              status: "active",
+              image: {
+                id: "img-12345"
+              },
+              server_type: {
+                id: "typ-12345"
+              },
+              cloud_ips: [],
+              interfaces: [
+                {
+                  id: "int-12345",
+                  ipv4_address: "10.0.0.0",
+                  ipv6_address: "2a02:1234:abcd:5678::1"
+                }
+              ],
+              server_groups: [],
+              snapshots: []
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        require "pry"
+        # binding.pry
+        expect { output }.to_not raise_error
+
+        aggregate_failures do
+          expect(stderr).not_to match("ERROR")
+          expect(stdout).to match("id: srv-12345")
+          expect(stdout).to match("status: active")
+          expect(stdout).to match("name: app-server1")
+        end
       end
     end
   end

--- a/spec/commands/users/show_spec.rb
+++ b/spec/commands/users/show_spec.rb
@@ -6,11 +6,76 @@ describe "brightbox users" do
     let(:stdout) { output.stdout }
     let(:stderr) { output.stderr }
 
-    context "" do
+    before do
+      WebMock.reset!
+
+      config_from_contents(API_CLIENT_CONFIG_CONTENTS)
+      stub_client_token_request
+      Brightbox.config.reauthenticate
+    end
+
+    context "without arguments" do
       let(:argv) { %w[users show] }
 
       it "does not error" do
         expect { output }.to_not raise_error
+
+        aggregate_failures do
+          expect(stderr).to match("ERROR: You must specify user IDs to show")
+          expect(stdout).to be_empty
+        end
+      end
+    end
+
+    context "with identifier argument" do
+      let(:argv) { %w[users show usr-90781] }
+
+      before do
+        # FIXME: Two requests, one with the parameter and one without
+        #        One for ALL tests (with VCR breaking things)
+        #        One for this test standalone
+        stub_request(:get, "#{api_url}/1.0/users/usr-90781")
+          .to_return(
+            status: 200,
+            body: {
+              id: "usr-90781",
+              email_address: "user@domain.test",
+              accounts: [
+                {
+                  id: "acc-12345",
+                  name: "Test account"
+                }
+              ]
+            }.to_json
+          )
+
+        # Same again but supporting the account_id parameter
+        stub_request(:get, "#{api_url}/1.0/users/usr-90781")
+          .with(query: hash_including(account_id: "acc-12345"))
+          .to_return(
+            status: 200,
+            body: {
+              id: "usr-90781",
+              email_address: "user@domain.test",
+              accounts: [
+                {
+                  id: "acc-12345",
+                  name: "Test account"
+                }
+              ]
+            }.to_json
+          )
+      end
+
+      it "does not error" do
+        expect { output }.to_not raise_error
+
+        aggregate_failures do
+          expect(stderr).to match("")
+          expect(stderr).not_to match("ERROR")
+          expect(stdout).to match("usr-90781")
+          expect(stdout).to match("email_address: user@domain.test")
+        end
       end
     end
   end

--- a/spec/commands/volumes/show_spec.rb
+++ b/spec/commands/volumes/show_spec.rb
@@ -8,45 +8,27 @@ describe "brightbox volumes show" do
   let(:stderr) { output.stderr }
 
   before do
+    WebMock.reset!
+
     config_from_contents(API_CLIENT_CONFIG_CONTENTS)
-
-    stub_request(:post, "http://api.brightbox.localhost/token")
-      .to_return(
-        status: 200,
-        body: JSON.dump(
-          access_token: "ACCESS-TOKEN",
-          refresh_token: "REFRESH_TOKEN"
-        )
-      )
-
+    stub_client_token_request
     Brightbox.config.reauthenticate
   end
 
   context "without arguments" do
     let(:argv) { %w[volumes show] }
 
-    before do
-      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes")
-        .with(query: hash_including(account_id: "acc-12345"))
-        .to_return(
-          status: 200,
-          body: volumes_response
-        )
-    end
-
-    it "does not error" do
+    it "reports missing IDs" do
       expect { output }.to_not raise_error
 
-      expect(stderr).to be_empty unless ENV["DEBUG"]
-
       aggregate_failures do
-        expect(stdout).to match("id: vol-12345")
-        expect(stdout).to match("id: vol-abcde")
+        expect(stderr).to match("ERROR: You must specify volume IDs to show")
+        expect(stdout).to be_empty
       end
     end
   end
 
-  context "with identifier" do
+  context "with identifier argument" do
     let(:argv) { %w[volumes show vol-88878] }
 
     before do
@@ -89,6 +71,53 @@ describe "brightbox volumes show" do
         expect(stdout).to match("source:")
         expect(stdout).to match("image: img-12345")
         expect(stdout).to match("locked: false")
+      end
+    end
+  end
+
+  context "with multiple identifiers" do
+    let(:argv) { %w[volumes show vol-88878 vol-99999] }
+
+    before do
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-88878")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-88878",
+            description: "A volume for testing",
+            filesystem_type: "ext4",
+            storage_type: "network",
+            size: 10_240,
+            status: "attached",
+            server: nil
+          )
+        )
+
+      stub_request(:get, "http://api.brightbox.localhost/1.0/volumes/vol-99999")
+        .with(query: hash_including(account_id: "acc-12345"))
+        .to_return(
+          status: 200,
+          body: volume_response(
+            id: "vol-99999",
+            description: "Another volume for testing",
+            filesystem_type: "ext4",
+            storage_type: "network",
+            size: 10_240,
+            status: "attached",
+            server: nil
+          )
+        )
+    end
+
+    it "does not error" do
+      expect { output }.to_not raise_error
+
+      expect(stderr).not_to match("ERROR")
+
+      aggregate_failures do
+        expect(stdout).to match("id: vol-88878")
+        expect(stdout).to match("id: vol-99999")
       end
     end
   end


### PR DESCRIPTION
When multiple arguments were issued to a `show` command, the expected behaviour is to make multiple API requests to get the full API data with all the data as exposed.

Some commands had incorrectly been implemented using the main index API call which includes lightweight responses which results in incorrect output as fields were missing in the output since they are not in the response.

Passing no arguments should have been an error but these variants would sometimes return ALL resources in the abridged format missing some fields.