### PR TITLE
Move Image `arch` to own column/remove from name

### DIFF
--- a/lib/brightbox-cli/images.rb
+++ b/lib/brightbox-cli/images.rb
@@ -16,7 +16,7 @@ module Brightbox
     end
 
     def self.default_field_order
-      %i[id owner type created_on status size name]
+      %i[id owner type created_on status size arch name]
     end
 
     # Filter out images that are not of the right type, account or status if the option is passed
@@ -84,7 +84,7 @@ module Brightbox
         locked: locked?,
         username: username,
         arch: arch,
-        name: name.to_s + " (#{arch})",
+        name: name.to_s,
         owner: official ? "brightbox" : owner_id,
         type: type,
         created_at: created_at,


### PR DESCRIPTION
Originally the image architecture was embedded into the name for display but that caused issues with parsing, especially if parentheses we used in the name.

It also resulted in duplication in the `images show` command as the `arch` field was also included but the name without was not.

This splits them apart rather than combining them.