### PR TITLE
ci: Use bundler-cache instead of manual Bundler install

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -32,9 +32,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install Bundler
-      run: gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1 | awk '{print $1}')
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,19 +22,20 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "head"]
+        include:
+          - ruby: "2.7"
+            bundler: "2.4.22"
     env:
       DEBUG: "true"
     steps:
     - uses: actions/checkout@v3
-    - name: Remove bundler version pin for head Ruby
-      if: matrix.ruby == 'head'
-      run: sed -i '/^BUNDLED WITH/{N;d}' Gemfile.lock
     - name: Set up Ruby ${{ matrix.ruby }}
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: ${{ matrix.bundler || 'default' }}
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,9 @@ jobs:
       DEBUG: "true"
     steps:
     - uses: actions/checkout@v3
+    - name: Remove bundler version pin for head Ruby
+      if: matrix.ruby == 'head'
+      run: sed -i '/^BUNDLED WITH/{N;d}' Gemfile.lock
     - name: Set up Ruby ${{ matrix.ruby }}
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,3 @@ DEPENDENCIES
   simplecov
   vcr (~> 2.5)
   webmock
-
-BUNDLED WITH
-   2.4.22


### PR DESCRIPTION
Let ruby/setup-ruby manage Bundler and dependency installation. This avoids the manual Bundler install step and handles version differences more reliably.